### PR TITLE
Remove _includes directory and slime extension from include view helper

### DIFF
--- a/lib/extatic/compiler/view_helpers.ex
+++ b/lib/extatic/compiler/view_helpers.ex
@@ -1,10 +1,16 @@
 defmodule Extatic.Compiler.ViewHelpers do
+  @included_file_ext ".slime"
+
   import Extatic.Utils
 
   def include(file) do
     with {:ok, content} <-
-           get_input_path()
-           |> Path.join(file)
+           [
+             get_input_path(),
+             get_includes_directory(),
+             file <> @included_file_ext
+           ]
+           |> Path.join()
            |> File.read!()
            |> Extatic.Compiler.Content.compile() do
       content

--- a/lib/extatic/utils.ex
+++ b/lib/extatic/utils.ex
@@ -1,4 +1,6 @@
 defmodule Extatic.Utils do
+  @default_include_dir "_includes"
+
   def get_input_path() do
     Application.fetch_env!(:extatic, :input)
     |> Path.expand()
@@ -7,5 +9,9 @@ defmodule Extatic.Utils do
   def get_output_path() do
     Application.fetch_env!(:extatic, :output)
     |> Path.expand()
+  end
+
+  def get_includes_directory() do
+    Application.get_env(:extatic, :include_dir, @default_include_dir)
   end
 end

--- a/priv/site/about.slime
+++ b/priv/site/about.slime
@@ -2,7 +2,7 @@
 layout: _layout.slime
 title: Extatic | About
 ---
-= include("_includes/header.slime")
+= include("header")
 
 h1 About
 p Hi! I like Elixir.


### PR DESCRIPTION
- Allow the former to be configurable and avoid having it to be repeated
everywhere.
- The latter is a common assumption and works in preparation for
allowing other preprocessors.