### PR TITLE
Decouple the preprocessor

### DIFF
--- a/lib/extatic/compiler/content.ex
+++ b/lib/extatic/compiler/content.ex
@@ -3,42 +3,39 @@ defmodule Extatic.Compiler.Content do
 
   import Extatic.Utils
 
-  def compile(content) do
+  def compile(content, preprocessor) do
     with {:ok, settings, content} <- Extatic.Compiler.Metadata.parse(content),
-         compiled <- render_template(content),
-         compiled <- append_layout(compiled, settings),
-         compiled <- append_development_layout(compiled) do
+         compiled <- render_template(content, preprocessor),
+         compiled <- append_layout(compiled, preprocessor, settings),
+         compiled <- append_development_layout(compiled, preprocessor) do
       {:ok, compiled}
     end
   end
 
-  defp append_layout(content, settings) do
+  defp append_layout(content, preprocessor, settings) do
     if Map.has_key?(settings, "layout") do
       get_input_path()
       |> Path.join(settings["layout"])
       |> File.read!()
-      |> render_template(children: content, title: Map.get(settings, "title"))
+      |> render_template(preprocessor, children: content, title: Map.get(settings, "title"))
     else
       content
     end
   end
 
-  defp append_development_layout(content) do
+  defp append_development_layout(content, preprocessor) do
     case Mix.env() do
       :dev ->
         Application.app_dir(:extatic, "priv/extatic/dev.slime")
         |> File.read!()
-        |> render_template(children: content)
+        |> render_template(preprocessor, children: content)
 
       _ ->
         content
     end
   end
 
-  defp render_template(content), do: render_template(content, [])
-
-  defp render_template(content, variables) do
-    ("- import Extatic.Compiler.ViewHelpers\n" <> content)
-    |> Slime.render([{:collections, Extatic.Collections.all()} | variables])
+  defp render_template(content, preprocessor, variables \\ []) do
+    preprocessor.render(content, [{:collections, Extatic.Collections.all()} | variables])
   end
 end

--- a/lib/extatic/compiler/file.ex
+++ b/lib/extatic/compiler/file.ex
@@ -7,7 +7,8 @@ defmodule Extatic.Compiler.File do
 
   def compile(file) do
     with {:ok, content} <- File.read(Path.join(get_input_path(), file)),
-         {:ok, compiled} <- Compiler.Content.compile(content),
+         preprocessor <- Compiler.Preprocessor.for(file),
+         {:ok, compiled} <- Compiler.Content.compile(content, preprocessor),
          new_file_name <- String.replace(file, Path.extname(file), ".html"),
          new_file_path <- Path.join(get_output_path(), new_file_name),
          _ <- File.mkdir_p!(Path.dirname(new_file_path)),
@@ -19,7 +20,7 @@ defmodule Extatic.Compiler.File do
         Logger.error("Failed to compile #{file}")
     end
   rescue
-    e in Slime.TemplateSyntaxError ->
+    e in Compiler.Preprocessor.SyntaxError ->
       Logger.error("Syntax error in #{file}\n#{e.line_number}: #{e.line}\n#{e.message}",
         file: file,
         line: e.line_number,

--- a/lib/extatic/compiler/preprocessor.ex
+++ b/lib/extatic/compiler/preprocessor.ex
@@ -1,0 +1,16 @@
+defmodule Extatic.Compiler.Preprocessor do
+  alias Extatic.Compiler.Preprocessor
+
+  @supported_preprocessors %{
+    ".slim" => Preprocessor.Slime,
+    ".slime" => Preprocessor.Slime,
+    ".eex" => Preprocessor.EEx
+  }
+
+  def for(file) do
+    extension = Path.extname(file)
+
+    @supported_preprocessors[extension] ||
+      raise CompileError, message: "unsupported file extension in #{file}"
+  end
+end

--- a/lib/extatic/compiler/preprocessor/eex.ex
+++ b/lib/extatic/compiler/preprocessor/eex.ex
@@ -1,0 +1,15 @@
+defmodule Extatic.Compiler.Preprocessor.EEx do
+  require EEx
+
+  def render(content, variables) do
+    ("<% import Extatic.Compiler.ViewHelpers %>\n" <> content)
+    |> EEx.eval_string(variables)
+  rescue
+    e in EEx.SyntaxError ->
+      raise Extatic.Compiler.Preprocessor.SyntaxError,
+        message: e.message,
+        line_number: e.line_number,
+        column: e.column,
+        line: ""
+  end
+end

--- a/lib/extatic/compiler/preprocessor/slime.ex
+++ b/lib/extatic/compiler/preprocessor/slime.ex
@@ -1,0 +1,21 @@
+if Code.ensure_loaded?(Slime) do
+  defmodule Extatic.Compiler.Preprocessor.Slime do
+    require Logger
+
+    def render(content, variables \\ []) do
+      do_render(content, variables)
+    rescue
+      e in Slime.TemplateSyntaxError ->
+        raise Extatic.Compiler.Preprocessor.SyntaxError,
+          message: e.message,
+          line_number: e.line_number,
+          line: e.line,
+          column: e.column
+    end
+
+    defp do_render(content, variables) do
+      ("- import Extatic.Compiler.ViewHelpers\n" <> content)
+      |> Slime.render(variables)
+    end
+  end
+end

--- a/lib/extatic/compiler/preprocessor/syntax_error.ex
+++ b/lib/extatic/compiler/preprocessor/syntax_error.ex
@@ -1,0 +1,3 @@
+defmodule Extatic.Compiler.Preprocessor.SyntaxError do
+  defexception [:line, :line_number, :message, :column]
+end

--- a/lib/extatic/compiler/view_helpers.ex
+++ b/lib/extatic/compiler/view_helpers.ex
@@ -1,12 +1,15 @@
 defmodule Extatic.Compiler.ViewHelpers do
   import Extatic.Utils
 
+  alias Extatic.Compiler
+
   def include(file) do
-    with {:ok, content} <-
+    with preprocessor <- Compiler.Preprocessor.for(file),
+         {:ok, content} <-
            get_input_path()
            |> Path.join(file)
            |> File.read!()
-           |> Extatic.Compiler.Content.compile() do
+           |> Compiler.Content.compile(preprocessor) do
       content
     else
       _ -> ""

--- a/mix.exs
+++ b/mix.exs
@@ -19,11 +19,11 @@ defmodule Extatic.MixProject do
 
   defp deps do
     [
-      {:slime, "~> 1.2"},
       {:cowboy, "~> 2.8"},
+      {:file_system, "~> 0.2.8"},
       {:plug, "~> 1.10"},
       {:plug_cowboy, "~> 2.3"},
-      {:file_system, "~> 0.2.8"},
+      {:slime, "~> 1.2", optional: true},
       {:yaml_elixir, "~> 2.4"}
     ]
   end


### PR DESCRIPTION
This allows us to support multiple preprocessors, inferred from the file
extension.