### PR TITLE
Fix development layout rendering multiple times

### DIFF
--- a/lib/extatic/compiler/file.ex
+++ b/lib/extatic/compiler/file.ex
@@ -6,7 +6,7 @@ defmodule Extatic.Compiler.File do
   alias Extatic.Compiler
 
   def compile(file) do
-    with {:ok, compiled, settings} <- process(file),
+    with {:ok, compiled, settings} <- compile_file(file),
          new_file_name <- get_output_file_name(file, settings),
          new_file_path <- get_output_path(new_file_name),
          _ <- File.mkdir_p!(Path.dirname(new_file_path)),
@@ -24,7 +24,7 @@ defmodule Extatic.Compiler.File do
   end
 
   def render(file, data) do
-    with {:ok, compiled, settings} <- process(file, data) do
+    with {:ok, compiled, settings} <- render_file(file, data) do
       Logger.debug("Rendered #{file}")
       {:ok, compiled, settings}
     else
@@ -38,24 +38,32 @@ defmodule Extatic.Compiler.File do
     end
   end
 
-  defp process(file, data \\ %{}) do
+  defp compile_file(file) do
     with {:ok, content} <- File.read(get_input_path(file)),
          {:ok, preprocessor} <- Compiler.Preprocessor.for(file) do
-      compile_content(file, content, preprocessor, data)
+      compile_content(file, content, preprocessor)
     end
   end
 
-  defp compile_content(file, content, preprocessor, data) do
-    Compiler.File.Content.compile(file, content, preprocessor, data)
+  defp render_file(file, data) do
+    with {:ok, content} <- File.read(get_input_path(file)),
+         {:ok, preprocessor} <- Compiler.Preprocessor.for(file) do
+      render_content(file, content, preprocessor, data)
+    end
+  end
+
+  defp compile_content(file, content, preprocessor) do
+    Compiler.File.Content.compile(file, content, preprocessor)
   rescue
     e in Compiler.Preprocessor.SyntaxError ->
-      Logger.error("Syntax error in #{file}\n#{e.line_number}: #{e.line}\n#{e.message}",
-        file: file,
-        line: e.line_number,
-        crash_reason: e.message
-      )
+      handle_syntax_error(file, e)
+  end
 
-      {:error, :syntax_error}
+  defp render_content(file, content, preprocessor, data) do
+    Compiler.File.Content.render(file, content, preprocessor, data)
+  rescue
+    e in Compiler.Preprocessor.SyntaxError ->
+      handle_syntax_error(file, e)
   end
 
   defp get_output_file_name(_file, %{permalink: permalink}) do
@@ -64,5 +72,15 @@ defmodule Extatic.Compiler.File do
 
   defp get_output_file_name(file, _) do
     String.replace(file, Path.extname(file), ".html")
+  end
+
+  defp handle_syntax_error(file, e) do
+    Logger.error("Syntax error in #{file}\n#{e.line_number}: #{e.line}\n#{e.message}",
+      file: file,
+      line: e.line_number,
+      crash_reason: e.message
+    )
+
+    {:error, :syntax_error}
   end
 end

--- a/lib/extatic/compiler/file/content.ex
+++ b/lib/extatic/compiler/file/content.ex
@@ -8,11 +8,17 @@ defmodule Extatic.Compiler.File.Content do
     File.Frontmatter
   }
 
-  def compile(file, content, preprocessor, data \\ %{}) do
+  def render(file, content, preprocessor, data \\ %{}) do
     with {:ok, template_data, content} <- Frontmatter.parse(content),
          data <- Map.merge(template_data, data) |> Map.put(:file_path, file),
          compiled <- render_template(content, preprocessor, data),
-         compiled <- append_layout(compiled, data),
+         compiled <- append_layout(compiled, data) do
+      {:ok, compiled, data}
+    end
+  end
+
+  def compile(file, content, preprocessor, data \\ %{}) do
+    with {:ok, compiled, data} <- render(file, content, preprocessor, data),
          compiled <- append_development_layout(compiled, preprocessor) do
       {:ok, compiled, data}
     end


### PR DESCRIPTION
Why:

* We were getting weird behaviours (application crashes, module
redefinitions, JS errors) due to always adding the development layout.

* We would include it at least two times, most of the time: once with the
layout.slime file and the other with the actual file (about.slime,
index.slime, etc)

This change addresses the need by:

* Distinguishing between renders (some other file requested the file
content) and compilations (we're meant to read a "top-level" file and
process it).
* Only adding the development layout in the latter.