### PR TITLE
Only refresh browsers after the compilation is completed

### DIFF
--- a/lib/extatic/application.ex
+++ b/lib/extatic/application.ex
@@ -27,7 +27,7 @@ defmodule Extatic.Application do
       [
         {
           Plug.Cowboy,
-          scheme: :http, plug: {Extatic.Router, []}, port: port(), dispatch: cowboy_dispatch()
+          scheme: :http, plug: {Extatic.Web.Router, []}, port: port(), dispatch: cowboy_dispatch()
         },
         Extatic.Watcher
       ]
@@ -40,8 +40,8 @@ defmodule Extatic.Application do
     [
       {:_,
        [
-         {"/ws", Extatic.SocketHandler, []},
-         {:_, Plug.Cowboy.Handler, {Extatic.Router, []}}
+         {"/ws", Extatic.Web.SocketHandler, []},
+         {:_, Plug.Cowboy.Handler, {Extatic.Web.Router, []}}
        ]}
     ]
   end

--- a/lib/extatic/compiler/incremental/node.ex
+++ b/lib/extatic/compiler/incremental/node.ex
@@ -18,6 +18,7 @@ defmodule Extatic.Compiler.Incremental.Node do
 
   use GenServer
 
+  alias Extatic.Web.BrowserSubscriptions
   alias Extatic.Compiler
   alias __MODULE__.Compile
 
@@ -55,6 +56,7 @@ defmodule Extatic.Compiler.Incremental.Node do
   @impl true
   def handle_call(:compile, _from, state) do
     with result <- Compile.run(state) do
+      BrowserSubscriptions.notify()
       {:reply, result, state}
     end
   end

--- a/lib/extatic/web/browser_subscriptions.ex
+++ b/lib/extatic/web/browser_subscriptions.ex
@@ -1,0 +1,40 @@
+defmodule Extatic.Web.BrowserSubscriptions do
+  use GenServer
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  def add(pid) do
+    GenServer.cast(__MODULE__, {:add, pid})
+  end
+
+  def notify do
+    GenServer.cast(__MODULE__, :notify)
+  end
+
+  def init(_) do
+    {:ok, %{subscribers: [], timer_ref: nil}}
+  end
+
+  def handle_cast({:add, pid}, state) do
+    {:noreply, %{state | subscribers: [pid | state.subscribers]}}
+  end
+
+  def handle_cast(:notify, state) do
+    if not is_nil(state.timer_ref) do
+      Process.cancel_timer(state.timer_ref)
+    end
+
+    timer_ref = Process.send_after(self(), :notify_subscribers, 400)
+
+    {:noreply, %{state | timer_ref: timer_ref}}
+  end
+
+  def handle_info(:notify_subscribers, state) do
+    state.subscribers
+    |> Enum.each(&send(&1, Application.fetch_env!(:extatic, :reload_msg)))
+
+    {:noreply, state}
+  end
+end

--- a/lib/extatic/web/router.ex
+++ b/lib/extatic/web/router.ex
@@ -1,4 +1,4 @@
-defmodule Extatic.Router do
+defmodule Extatic.Web.Router do
   use Plug.Router
   use Plug.Debugger
   require Logger

--- a/lib/extatic/web/socket_handler.ex
+++ b/lib/extatic/web/socket_handler.ex
@@ -1,4 +1,4 @@
-defmodule Extatic.SocketHandler do
+defmodule Extatic.Web.SocketHandler do
   @behaviour :cowboy_websocket
 
   require Logger
@@ -16,7 +16,7 @@ defmodule Extatic.SocketHandler do
   def websocket_handle({:text, message}, state) do
     if message == "subscribe" do
       Logger.debug("Browser subscribing for changes")
-      Extatic.Watcher.subscribe(self())
+      Extatic.Web.BrowserSubscriptions.add(self())
     end
 
     {:ok, state}


### PR DESCRIPTION
There's a timing issue when the browser refreshes. For instance, let's say we have an `about.slime` that includes ` _header.slime`. When the `_header.slime` changes, we compile it's and asynchronously tell the `about.slime` to recompile. After that, we tell the browser to refresh. The issue is that it doesn't wait for the `about.slime` to recompile before refreshing the browser.

In this PR, we move the subscription logic from the watcher into a new module `BrowserSubscribers` and the existing `Node`. The sockets subscribe to the `BrowserSubscribers`, and the `Node` sends a notify message after it compiles. There's a throttle mechanism so that the `BrowserSubscribers` only refreshes the browsers if it doesn't receive any new notify message for 400ms.