### PR TITLE
Fix renderer ast function check

### DIFF
--- a/lib/still/preprocessor/renderer.ex
+++ b/lib/still/preprocessor/renderer.ex
@@ -44,7 +44,7 @@ defmodule Still.Preprocessor.Renderer do
           |> Map.to_list()
 
         renderer_ast =
-          if Module.defines?(__MODULE__, {:ast, 0}) do
+          if Kernel.function_exported?(__MODULE__, :ast, 0) do
             ast()
           else
             []


### PR DESCRIPTION
Why:

* It would crash since `Module.defines?/2` assumes the module isn't
compiled yet.

This change addresses the need by:

* Using `Kernel.function_exported?/3` instead.