### PR TITLE
Slime is no longer optional

### DIFF
--- a/lib/still/preprocessor/slime.ex
+++ b/lib/still/preprocessor/slime.ex
@@ -1,27 +1,25 @@
-if Code.ensure_loaded?(Slime) do
-  defmodule Still.Preprocessor.Slime do
-    require Slime
+defmodule Still.Preprocessor.Slime do
+  require Slime
 
-    alias Still.Preprocessor
-    alias Still.Preprocessor.Slime.Renderer
+  alias Still.Preprocessor
+  alias Still.Preprocessor.Slime.Renderer
 
-    use Preprocessor, ext: ".html"
+  use Preprocessor, ext: ".html"
 
-    @impl true
-    def render(content, variables) do
-      %{content: do_render(content, variables), variables: variables}
-    rescue
-      e in Slime.TemplateSyntaxError ->
-        raise Preprocessor.SyntaxError,
-          message: e.message,
-          line_number: e.line_number,
-          line: e.line,
-          column: e.column
-    end
+  @impl true
+  def render(content, variables) do
+    %{content: do_render(content, variables), variables: variables}
+  rescue
+    e in Slime.TemplateSyntaxError ->
+      raise Preprocessor.SyntaxError,
+        message: e.message,
+        line_number: e.line_number,
+        line: e.line,
+        column: e.column
+  end
 
-    defp do_render(content, variables) do
-      Renderer.create(content, variables)
-      |> apply(:render, variables |> Map.values())
-    end
+  defp do_render(content, variables) do
+    Renderer.create(content, variables)
+    |> apply(:render, variables |> Map.values())
   end
 end

--- a/lib/still/preprocessor/slime/renderer.ex
+++ b/lib/still/preprocessor/slime/renderer.ex
@@ -1,23 +1,21 @@
-if Code.ensure_loaded?(Slime) do
-  defmodule Still.Preprocessor.Slime.Renderer do
-    use Still.Preprocessor.Renderer,
-      extensions: [".slime"],
-      preprocessor: Still.Preprocessor.Slime
+defmodule Still.Preprocessor.Slime.Renderer do
+  use Still.Preprocessor.Renderer,
+    extensions: [".slime"],
+    preprocessor: Still.Preprocessor.Slime
 
-    @impl true
-    def compile(content, _variables) do
-      info = [file: __ENV__.file, line: __ENV__.line]
+  @impl true
+  def compile(content, _variables) do
+    info = [file: __ENV__.file, line: __ENV__.line]
 
-      Slime.Renderer.precompile(content)
-      |> EEx.compile_string(info)
-    end
+    Slime.Renderer.precompile(content)
+    |> EEx.compile_string(info)
+  end
 
-    @impl true
-    def ast do
-      quote do
-        require EEx
-        require Slime
-      end
+  @impl true
+  def ast do
+    quote do
+      require EEx
+      require Slime
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Still.MixProject do
       {:file_system, "~> 0.2.8"},
       {:plug, "~> 1.10"},
       {:plug_cowboy, "~> 2.3"},
-      {:slime, "~> 1.2", optional: true},
+      {:slime, "~> 1.2"},
       {:yaml_elixir, "~> 2.4"}
     ]
   end


### PR DESCRIPTION
We need Slime because our development layout is written in Slime. It
also makes sense to include Slime by default because this goes with our
philosophy to require as little configuration as possible to get
started.