### PR TITLE
Start BrowserSubscriptions

### DIFF
--- a/lib/still/application.ex
+++ b/lib/still/application.ex
@@ -29,7 +29,8 @@ defmodule Still.Application do
           Plug.Cowboy,
           scheme: :http, plug: {Still.Web.Router, []}, port: port(), dispatch: cowboy_dispatch()
         },
-        Still.Watcher
+        Still.Watcher,
+        Still.Web.BrowserSubscriptions
       ]
     else
       []


### PR DESCRIPTION
For some reason this GenServer is no longer in the list. Adding it
solves the issue with the browser not automatically refreshing.