### PR TITLE
Prevent application start timeout

### DIFF
--- a/lib/still/watcher.ex
+++ b/lib/still/watcher.ex
@@ -15,12 +15,16 @@ defmodule Still.Watcher do
   end
 
   def init(_) do
+    {:ok, %{}, {:continue, :async_compile}}
+  end
+
+  def handle_continue(:async_compile, state) do
     {:ok, watcher_pid} = FileSystem.start_link(dirs: [get_input_path()])
     FileSystem.subscribe(watcher_pid)
 
     Compiler.Traverse.run()
 
-    {:ok, %{}}
+    {:noreply, state}
   end
 
   def handle_info({:file_event, _watcher_pid, {file, [_, :removed]}}, state) do


### PR DESCRIPTION
Why:

* When starting the application in a separate project, via `mix
still.dev`, it would crash with the following error:

```
19:21:34.539 [info]  Application still exited: Still.Application.start(:normal, []) returned an error: shutdown: failed to start child: Still.Watcher
    ** (EXIT) exited in: GenServer.call(#PID<0.475.0>, :compile, 5000)
        ** (EXIT) time out
==> site
** (Mix) Could not start application still: Still.Application.start(:normal, []) returned an error: shutdown: failed to start child: Still.Watcher
    ** (EXIT) exited in: GenServer.call(#PID<0.475.0>, :compile, 5000)
        ** (EXIT) time out
```

* This was due to a timeout when starting the application: it would
start `Still.Watcher` which in turn would traverse the code on the
`init/1` callback.
* As it happens, `init/1` blocks `start_link/3` until it returns,
causing the application start to crash.

This change addresses the need by:

* Moving the code traversal to a `handle_continue/2` callback