### PR TITLE
Fix Markdown with HTML tags

### DIFF
--- a/lib/still/compiler/view_helpers/content_tag.ex
+++ b/lib/still/compiler/view_helpers/content_tag.ex
@@ -10,11 +10,7 @@ defmodule Still.Compiler.ViewHelpers.ContentTag do
       |> Enum.concat(data_attrs)
       |> Enum.join(" ")
 
-    """
-    #{opening_tag(tag, content, attrs)}
-      #{content}
-    #{closing_tag(tag, content)}
-    """
+    opening_tag(tag, content, attrs) <> content <> closing_tag(tag, content)
   end
 
   def opening_tag(tag, content, attrs) when is_nil(content) do

--- a/priv/site/posts/post_2.md
+++ b/priv/site/posts/post_2.md
@@ -6,4 +6,6 @@ title: "Post #2"
 
 # Post 2
 
+## hello <%= link "world", to: "/" %>
+
 This is _markdown_. **Nice!**.


### PR DESCRIPTION
Why:

* When doing `# hello <%= link "world", to: "/" %>` the generated code
would be:

```markdown

# hello <a href="/">
world
</a>
```

due to the way the content tags were being generated, enforcing
newlines.

This change addresses the need by:

* Generating content tags without newlines or spaces.
* Adding an example in the sample site that addresses this.