### PR TITLE
Fix link_to_css and link_to_js

### DIFF
--- a/lib/still/compiler/view_helpers/link_to_css.ex
+++ b/lib/still/compiler/view_helpers/link_to_css.ex
@@ -14,7 +14,7 @@ defmodule Still.Compiler.ViewHelpers.LinkToCSS do
       |> Enum.join(" ")
 
     with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
-         %{output_file: output_file} <- Incremental.Node.render(pid, %{}) do
+         %{output_file: output_file} <- Incremental.Node.compile(pid) do
       """
       <link rel="stylesheet" #{link_opts} href=#{UrlFor.render(output_file)} />
       """

--- a/lib/still/compiler/view_helpers/link_to_js.ex
+++ b/lib/still/compiler/view_helpers/link_to_js.ex
@@ -14,7 +14,7 @@ defmodule Still.Compiler.ViewHelpers.LinkToJS do
       |> Enum.join(" ")
 
     with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
-         %{output_file: output_file} <- Incremental.Node.render(pid, %{}) do
+         %{output_file: output_file} <- Incremental.Node.compile(pid) do
       """
       <script #{link_opts} src=#{UrlFor.render(output_file)}></script>
       """


### PR DESCRIPTION
These helpers must use `compile` to ensure that a file is placed in the output folder.