### PR TITLE
Confirm before overriding files with mix still.new

### DIFF
--- a/installer/lib/mix/still_new/generator.ex
+++ b/installer/lib/mix/still_new/generator.ex
@@ -2,11 +2,6 @@ defmodule Still.New.Generator do
   @root Path.expand("../../..", __DIR__)
 
   def run(project) do
-    ensure_base_path_exists(project)
-    copy_template(project)
-  end
-
-  defp copy_template(project) do
     for {input, output} <- template_files(project),
         do: copy_file(input, output, project)
   end
@@ -24,7 +19,7 @@ defmodule Still.New.Generator do
 
   defp copy_file(input, output, project) do
     input_path = template_path(input)
-    output_path = output_path(project, output)
+    output_path = project.path <> output
     metadata = eex_metadata(project)
 
     Mix.Generator.copy_template(input_path, output_path, metadata)
@@ -34,30 +29,11 @@ defmodule Still.New.Generator do
     "#{@root}/templates/#{input}"
   end
 
-  defp output_path(project, output) do
-    (project.path <> output)
-    |> Path.expand()
-  end
-
   defp eex_metadata(project) do
     [
       app_module: project.module,
       app_name: project.name,
       still_version: project.version
     ]
-  end
-
-  defp ensure_base_path_exists(%{path: path}) do
-    cwd = File.cwd!()
-    target = path |> Path.expand() |> Path.dirname()
-
-    if cwd == target do
-      true
-    else
-    path
-    |> Path.expand()
-    |> Path.dirname()
-    |> Mix.Generator.create_directory()
-    end
   end
 end

--- a/installer/mix.exs
+++ b/installer/mix.exs
@@ -15,7 +15,7 @@ defmodule Still.New.MixProject do
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :eex]]
   end
 
   defp deps do

--- a/installer/templates/config/dev.exs
+++ b/installer/templates/config/dev.exs
@@ -1,4 +1,5 @@
 import Config
 
 config :still,
-  dev_layout: true
+  dev_layout: true,
+  profiler: true

--- a/installer/templates/config/test.exs
+++ b/installer/templates/config/test.exs
@@ -1,0 +1,1 @@
+import Config

--- a/installer/templates/lib/app_name.ex
+++ b/installer/templates/lib/app_name.ex
@@ -1,2 +1,2 @@
-defmodule <%= app_module %> do
+defmodule <%= @app_module %> do
 end

--- a/installer/templates/mix.exs
+++ b/installer/templates/mix.exs
@@ -1,9 +1,9 @@
-defmodule <%= app_module %>.MixProject do
+defmodule <%= @app_module %>.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :<%= app_name %>,
+      app: :<%= @app_name %>,
       version: "0.1.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
@@ -28,7 +28,7 @@ defmodule <%= app_module %>.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
-      {:still, "~> <%= still_version %>"}
+      {:still, "~> <%= @still_version %>"}
     ]
   end
 end


### PR DESCRIPTION
Currently running `mix still.new` for an existing directory overrides
any existing file, regardless of their content.

This update makes use of `Mix.Generator.copy_template/4` to ask users
for confirmation if the content of the file is different.