### PR TITLE
Add Rust as dependency

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 elixir 1.10.4-otp-23
 erlang 23.0.3
+rust 1.49.0

--- a/bin/setup
+++ b/bin/setup
@@ -16,6 +16,7 @@ if ! installed "elixir"; then
     pp_info "setup" "Using asdf..."
     set +e
     asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git 2>/dev/null
+    asdf plugin-add rust https://github.com/code-lever/asdf-rust.git 2>/dev/null
     set -e
 
     asdf install


### PR DESCRIPTION
It's currently impossible to compile the project without a recent
version of Rust. This PR adds it as an explicit dependency by including
it in the `.tool-versions` file and in the `bin/setup` script.

`bin/setup` doesn't go deep into installing Rust as we're doing the best
we can to remove it as a dependency.