### PR TITLE
Update mix config for site deploy

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -25,9 +25,9 @@ jobs:
             _site
           key: mix-${{ hashFiles('mix.lock') }}
 
-      - run: mix deps.get
+      - run: MIX_ENV=site mix deps.get
 
-      - run: mix still.compile
+      - run: MIX_ENV=site mix still.compile
 
       - uses: peaceiris/actions-gh-pages@v3
         with:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,12 @@
 import Config
 
 config :still,
-  view_helpers: [],
   dev_layout: false,
-  url_fingerprinting: false
+  input: Path.join(Path.dirname(__DIR__), "priv/site"),
+  output: Path.join(Path.dirname(__DIR__), "_site"),
+  pass_through_copy: [~r/.*jpe?g/, "subvisual.png", "images", "fonts"],
+  url_fingerprinting: false,
+  view_helpers: []
 
 config :mogrify,
   mogrify_command: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,7 +2,4 @@ import Config
 
 config :still,
   dev_layout: true,
-  base_url: "http://localhost:3000",
-  input: Path.join(Path.dirname(__DIR__), "priv/site"),
-  output: Path.join(Path.dirname(__DIR__), "_site"),
-  pass_through_copy: [~r/.*jpe?g/, "subvisual.png", "fonts", "images"]
+  base_url: "http://localhost:3000"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,8 +1,1 @@
 import Config
-
-config :still,
-  url_fingerprinting: true,
-  base_url: "https://subvisual.github.io/still/",
-  input: Path.join(Path.dirname(__DIR__), "priv/site"),
-  output: Path.join(Path.dirname(__DIR__), "_site"),
-  pass_through_copy: [~r/.*jpe?g/, "subvisual.png", "images"]

--- a/config/site.exs
+++ b/config/site.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :still,
+  url_fingerprinting: true,
+  base_url: "http://still-ex.github.io/still"

--- a/lib/still/site/github.ex
+++ b/lib/still/site/github.ex
@@ -1,4 +1,4 @@
-if Mix.env() == :dev do
+if Mix.env() != :prod do
   defmodule Still.Site.Github do
     @rate_limited_stargazers 418
     @rate_limited_username "@ratelimited"


### PR DESCRIPTION
We use :dev to work on the website, :prod is used when the users of this
library install it, so we need a new one, :site, for when we are
deploying the site. We can't use :dev because the config has to be
different.