### PR TITLE
Fix Watcher crashing when removing a file

### DIFF
--- a/lib/still/compiler/incremental/registry.ex
+++ b/lib/still/compiler/incremental/registry.ex
@@ -20,7 +20,7 @@ defmodule Still.Compiler.Incremental.Registry do
   Terminates the `Still.Compiler.Incremental.Node` corresponding to the given file name.
   """
   def terminate_file_process(file) do
-    DynamicSupervisor.terminate_child(__MODULE__, Process.whereis(file |> String.to_atom()))
+    DynamicSupervisor.terminate_child(__MODULE__, Process.whereis(file))
     :ok
   end
 


### PR DESCRIPTION
When a file is removed, the watcher is crashing due to the `Registry`
call to `DynamicSupervisor.terminate_child/2`.

The second argument is `nil` because it attempts to get the PID by
running `Process.whereis(file |> String.to_atom())`. However, the
registered name is a string.

Since this call crashes due to the lack of a function clause, the
watcher would crash as well.