### PR TITLE
Fix profiler output

### DIFF
--- a/lib/still/preprocessor/output_path.ex
+++ b/lib/still/preprocessor/output_path.ex
@@ -9,6 +9,10 @@ defmodule Still.Preprocessor.OutputPath do
   use Preprocessor
 
   @impl true
+  def render(%{output_file: output_file} = file) when not is_nil(output_file) do
+    file
+  end
+
   def render(%{metadata: %{permalink: permalink}} = file) do
     %{file | output_file: permalink}
   end

--- a/lib/still/profiler.ex
+++ b/lib/still/profiler.ex
@@ -27,7 +27,6 @@ defmodule Still.Profiler do
   alias Still.{Preprocessor, SourceFile}
   alias Still.Utils
 
-  @impl true
   def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
@@ -88,6 +87,7 @@ defmodule Still.Profiler do
 
     %SourceFile{
       input_file: @profiler_layout,
+      output_file: "profiler/index.html",
       content: content,
       run_type: :compile,
       metadata: %{stats: stats}


### PR DESCRIPTION
The profiler output was wrong and when setting it, it was being
overriden due to the lack of a specific function clause in
`AddOutputPath`.