### PR TITLE
Update Profiler

### DIFF
--- a/lib/still/source_file.ex
+++ b/lib/still/source_file.ex
@@ -15,7 +15,8 @@ defmodule Still.SourceFile do
     content: nil,
     metadata: %{},
     extension: nil,
-    run_type: :render
+    run_type: :render,
+    profilable: true
   ]
 
   @type t :: %__MODULE__{
@@ -24,6 +25,7 @@ defmodule Still.SourceFile do
           extension: binary() | nil,
           input_file: binary(),
           output_file: binary() | nil,
-          metadata: map()
+          metadata: map(),
+          profilable: boolean()
         }
 end

--- a/priv/still/profiler.slime
+++ b/priv/still/profiler.slime
@@ -116,9 +116,27 @@ html
                     summary
                       span = stat.source_file.input_file
 
+                    strong.small
+                      ' Total render time:
+
+                    span.small #{stat.delta}ms
+
+                    br
+
+                    strong.small
+                      ' Hash of metadata:
+
+                    span.small #{stat.hash}
+
+                    br
+
+                    strong.small Variables:
+
+                    br
+
                     span.small
                       = if stat.source_file.metadata == %{} do
-                        | No variables
+                        | &nbsp;&nbsp;No variables
                       - else
                         = for {k, v} <- stat.source_file.metadata do
                           p
@@ -139,7 +157,8 @@ html
                             = if k == :children do
                               a.previewButton href="#" View as HTML
                 td
-                  span.small.delta = "(#{stat.delta}ms)"
+                  span.small.delta
+                    | Rendered #{stat.nr_renders}x (avg. #{trunc(stat.delta / stat.nr_renders)} ms)
 
         .preview
           iframe#previewHTML src="javascript:void(0);"

--- a/test/still/profiler_test.exs
+++ b/test/still/profiler_test.exs
@@ -8,39 +8,62 @@ defmodule Still.ProfilerTest do
     test "saves the source file and the delta" do
       source_file = source_file_fixture()
 
-      {:noreply, state} = Profiler.handle_cast({:register, source_file, 100}, %{})
+      {:noreply, state} = Profiler.handle_cast({:register, source_file, 100}, %{stats: %{}})
 
-      assert [%{source_file: ^source_file, delta: 100}] = Map.values(state)
+      assert [
+               %{
+                 source_file: ^source_file,
+                 delta: 100,
+                 nr_renders: 1,
+                 hash: _
+               }
+             ] = Map.values(state.stats)
+    end
+
+    test "saves the number of times a file is rendered" do
+      source_file = source_file_fixture()
+
+      {:noreply, state} = Profiler.handle_cast({:register, source_file, 100}, %{stats: %{}})
+      {:noreply, state} = Profiler.handle_cast({:register, source_file, 100}, state)
+
+      assert [
+               %{
+                 source_file: ^source_file,
+                 delta: 200,
+                 nr_renders: 2,
+                 hash: _
+               }
+             ] = Map.values(state.stats)
     end
 
     test "generates different hashes for different files" do
       source_file_1 = source_file_fixture(input_file: "file1.md")
       source_file_2 = source_file_fixture(input_file: "file2.md")
 
-      {:noreply, state} = Profiler.handle_cast({:register, source_file_1, 100}, %{})
+      {:noreply, state} = Profiler.handle_cast({:register, source_file_1, 100}, %{stats: %{}})
       {:noreply, state} = Profiler.handle_cast({:register, source_file_2, 100}, state)
 
-      assert [_, _] = Map.values(state)
+      assert [_, _] = Map.values(state.stats)
     end
 
     test "generates different hashes for the same file with different metadata" do
       source_file_1 = source_file_fixture(input_file: "file.md", metadata: %{a: 1})
       source_file_2 = source_file_fixture(input_file: "file.md", metadata: %{b: 1})
 
-      {:noreply, state} = Profiler.handle_cast({:register, source_file_1, 100}, %{})
+      {:noreply, state} = Profiler.handle_cast({:register, source_file_1, 100}, %{stats: %{}})
       {:noreply, state} = Profiler.handle_cast({:register, source_file_2, 100}, state)
 
-      assert [_, _] = Map.values(state)
+      assert [_, _] = Map.values(state.stats)
     end
 
     test "generates equal hashes for functionally equivalent files" do
       source_file_1 = source_file_fixture(input_file: "file.md", metadata: %{a: 1})
       source_file_2 = source_file_fixture(input_file: "file.md", metadata: %{"a" => 1})
 
-      {:noreply, state} = Profiler.handle_cast({:register, source_file_1, 100}, %{})
+      {:noreply, state} = Profiler.handle_cast({:register, source_file_1, 100}, %{stats: %{}})
       {:noreply, state} = Profiler.handle_cast({:register, source_file_2, 100}, state)
 
-      assert [_] = Map.values(state)
+      assert [_] = Map.values(state.stats)
     end
   end
 


### PR DESCRIPTION
* It was crashing because it was trying to profile itself. This is
  solved by adding a `profilable` field to the `Still.SourceFile`.
* The deltas were being overriden because it was running between every
  preprocessor instead of a preprocessor chain.
* Improve performance by only calling for specific preprocessors.
* Save information for successive renders for the same file, including
  total delta and amount of renders.