### PR TITLE
Add default value to Watcher

### DIFF
--- a/lib/still/watcher.ex
+++ b/lib/still/watcher.ex
@@ -49,6 +49,8 @@ defmodule Still.Watcher do
 
       Enum.member?(events, :removed) ->
         Incremental.Registry.terminate_file_process(file)
+
+      true -> nil
     end
 
     {:noreply, state}


### PR DESCRIPTION
Ignores events sent from the `file_watcher` that we don't have use for
