### PR TITLE
Logs a warning instead of raising an error for missing Preprocessors

### DIFF
--- a/lib/still/preprocessor.ex
+++ b/lib/still/preprocessor.ex
@@ -131,9 +131,7 @@ defmodule Still.Preprocessor do
     preprocessors()[Path.extname(file)]
     |> case do
       nil ->
-        raise PreprocessorError,
-          message: "Preprocessors not found for #{file}",
-          source_file: source_file
+        Logger.warn("Preprocessors not found for file: #{file}")
 
       preprocessors ->
         preprocessors


### PR DESCRIPTION
Instead of raising an error and crashing the server when a file doesn't
have a defined preprocessor, logs a warning to the server.
