### PR TITLE
The task still.compile starts all registered apps

### DIFF
--- a/lib/mix/tasks/still.compile.ex
+++ b/lib/mix/tasks/still.compile.ex
@@ -4,8 +4,7 @@ defmodule Mix.Tasks.Still.Compile do
   @doc false
   def run(_) do
     Mix.Task.run("compile")
-
-    {:ok, _} = Application.ensure_all_started(:still)
+    Mix.Task.run("app.start")
 
     Still.Compiler.CompilationStage.subscribe()
 

--- a/lib/still/compiler/compilation_stage.ex
+++ b/lib/still/compiler/compilation_stage.ex
@@ -96,6 +96,7 @@ defmodule Still.Compiler.CompilationStage do
      }}
   end
 
+  @impl true
   def handle_info(:notify_subscribers, %{to_compile: []} = state) do
     state.subscribers
     |> Enum.each(fn pid ->
@@ -109,7 +110,6 @@ defmodule Still.Compiler.CompilationStage do
     {:noreply, state}
   end
 
-  @impl true
   def handle_info(:run, %{to_compile: [], changed: true} = state) do
     Process.send(self(), :notify_subscribers, [])
 


### PR DESCRIPTION
This change addresses two issues with the compilation task:

1. The task `still.compile` needs to start all apps. The compilation task didn't start the supervision tree of the applications using still. For instance, on my website, I have use [elixir-nodejs](https://github.com/revelrylabs/elixir-nodejs), which needs to be part of a supervision tree.

2. The compilation stage didn't wait for all files to be compiled before it sends the `:bus_empty` message to its subscribers. The `:run` message is sent 900ms after any file is compiled. The compilation of a file may trigger the compilation of other files, but there's no guarantee that the next `:run` arrives before the messages that add those new files. To solve that, we introduce a second message, `:notify_subcribers` that's sent immediately after a `:run` finds an empty queue. This should be enough to ensure that there are no other relevant messages in the mailbox.