### PR TITLE
Improve error handling

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -48,4 +48,4 @@ jobs:
         mix deps.get
 
     - name: Run tests
-      run: mix test
+      run: mix test --timeout 120000

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,14 +18,12 @@ jobs:
         elixir:
           - 1.10.4
           - 1.11.3
-        rust:
-          - 1.49.0
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-elixir@v1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,5 +3,4 @@ import Config
 config :still,
   base_url: "http://localhost:3000",
   input: Path.join(Path.dirname(__DIR__), "test/fixture/site"),
-  output: Path.join(Path.dirname(__DIR__), "._test_site"),
-  compilation_timeout: 45000
+  output: Path.join(Path.dirname(__DIR__), "._test_site")

--- a/lib/still/compiler/error_cache.ex
+++ b/lib/still/compiler/error_cache.ex
@@ -14,10 +14,6 @@ defmodule Still.Compiler.ErrorCache do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
-  def stop() do
-    GenServer.stop(__MODULE__, :ok)
-  end
-
   @doc """
   Save the given error or clear it if the compilation was successful.
 

--- a/lib/still/compiler/error_cache.ex
+++ b/lib/still/compiler/error_cache.ex
@@ -22,6 +22,10 @@ defmodule Still.Compiler.ErrorCache do
     GenServer.call(__MODULE__, {:set, result})
   end
 
+  def clear(input_file) do
+    GenServer.cast(__MODULE__, {:clear, input_file})
+  end
+
   @doc """
   Retrieve all saved errors, for all files.
   """
@@ -54,6 +58,10 @@ defmodule Still.Compiler.ErrorCache do
   end
 
   @impl true
+  def handle_cast({:clear, input_file}, state) do
+    {:noreply, state |> Map.delete(input_file)}
+  end
+
   def handle_cast(_, state) do
     {:noreply, state}
   end

--- a/lib/still/compiler/view_helpers.ex
+++ b/lib/still/compiler/view_helpers.ex
@@ -17,7 +17,8 @@ defmodule Still.Compiler.ViewHelpers do
         ViewHelpers.ContentTag,
         ViewHelpers.ResponsiveImage,
         ViewHelpers.SafeHTML,
-        ViewHelpers.Truncate
+        ViewHelpers.Truncate,
+        PreprocessorError
       }
 
       alias __MODULE__
@@ -60,6 +61,9 @@ defmodule Still.Compiler.ViewHelpers do
 
           content
         else
+          %PreprocessorError{} = e ->
+            raise e
+
           _ ->
             Logger.error("File process not found for #{file}")
             ""

--- a/lib/still/compiler/view_helpers.ex
+++ b/lib/still/compiler/view_helpers.ex
@@ -53,7 +53,7 @@ defmodule Still.Compiler.ViewHelpers do
       def include(file, metadata, opts) do
         with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
              subscriber <- include_subscriber(opts),
-             metadata <- Map.put(metadata, :parent, subscriber),
+             metadata <- Map.put(metadata, :dependency_chain, @env[:dependency_chain]),
              %SourceFile{content: content} <- Incremental.Node.render(pid, metadata, subscriber) do
           if subscriber do
             Incremental.Node.add_subscription(self(), file)

--- a/lib/still/compiler/view_helpers/responsive_image.ex
+++ b/lib/still/compiler/view_helpers/responsive_image.ex
@@ -62,8 +62,8 @@ defmodule Still.Compiler.ViewHelpers.ResponsiveImage do
     |> Enum.join(", ")
   end
 
-  defp get_render_data(_, %{sizes: _} = image_opts) do
-    %{image_opts: image_opts}
+  defp get_render_data(file, %{sizes: _} = image_opts) do
+    %{image_opts: image_opts, dependency_chain: [file]}
   end
 
   defp get_render_data(file, image_opts) do
@@ -82,6 +82,6 @@ defmodule Still.Compiler.ViewHelpers.ResponsiveImage do
         |> Enum.map(&(&1 * step_width))
       )
 
-    %{image_opts: image_opts}
+    %{image_opts: image_opts, dependency_chain: [file]}
   end
 end

--- a/lib/still/preprocessor.ex
+++ b/lib/still/preprocessor.ex
@@ -86,13 +86,13 @@ defmodule Still.Preprocessor do
   @doc """
   Runs the preprocessor pipeline for the given file.
   """
-  @spec run(SourceFile.t()) :: SourceFile.t()
+  @spec run(SourceFile.t()) :: SourceFile.t() | {:error, any()}
   def run(file) do
     file
     |> run(__MODULE__.for(file))
   end
 
-  @spec run(SourceFile.t(), list(module())) :: SourceFile.t()
+  @spec run(SourceFile.t(), list(module())) :: SourceFile.t() | {:error, any()}
   def run(file, []) do
     file
   end
@@ -135,27 +135,8 @@ defmodule Still.Preprocessor do
       preprocessor.run(file)
       |> run(remaining_preprocessors)
     catch
-      :error,
-      %PreprocessorError{
-        message: message,
-        preprocessor: preprocessor,
-        remaining_preprocessors: remaining_preprocessors,
-        source_file: source_file,
-        stacktrace: stacktrace
-      } = e ->
-        if String.contains?(source_file.input_file, file.input_file) do
-          raise e
-        else
-          raise PreprocessorError,
-            message: message,
-            preprocessor: preprocessor,
-            remaining_preprocessors: remaining_preprocessors,
-            source_file: %{
-              source_file
-              | input_file: "#{file.input_file} -> #{source_file.input_file}"
-            },
-            stacktrace: stacktrace
-        end
+      :error, %PreprocessorError{} = e ->
+        raise e
 
       :error, %{description: description} when description != "" ->
         raise PreprocessorError,

--- a/lib/still/preprocessor/add_layout.ex
+++ b/lib/still/preprocessor/add_layout.ex
@@ -31,12 +31,14 @@ defmodule Still.Preprocessor.AddLayout do
       |> Map.drop([:tag, :layout, :permalink, :input_file])
       |> Map.put(:children, children)
 
-    %{content: content} =
-      layout_file
-      |> Incremental.Registry.get_or_create_file_process()
-      |> Incremental.Node.render(layout_metadata, input_file)
-
-    %{file | content: content}
+    with %{content: content} <-
+           layout_file
+           |> Incremental.Registry.get_or_create_file_process()
+           |> Incremental.Node.render(layout_metadata, input_file) do
+      %{file | content: content}
+    else
+      error -> raise error
+    end
   end
 
   def render(file), do: file

--- a/lib/still/preprocessor/add_layout.ex
+++ b/lib/still/preprocessor/add_layout.ex
@@ -22,6 +22,7 @@ defmodule Still.Preprocessor.AddLayout do
         %{
           content: children,
           input_file: input_file,
+          dependency_chain: dependency_chain,
           metadata: %{layout: layout_file} = metadata
         } = file
       )
@@ -30,6 +31,7 @@ defmodule Still.Preprocessor.AddLayout do
       metadata
       |> Map.drop([:tag, :layout, :permalink, :input_file])
       |> Map.put(:children, children)
+      |> Map.put(:dependency_chain, dependency_chain)
 
     with %{content: content} <-
            layout_file

--- a/lib/still/preprocessor/eex.ex
+++ b/lib/still/preprocessor/eex.ex
@@ -19,10 +19,17 @@ defmodule Still.Preprocessor.EEx do
     %{file | content: do_render(file)}
   end
 
-  defp do_render(%{metadata: metadata} = file) do
+  defp do_render(
+         %{
+           metadata: metadata,
+           input_file: input_file,
+           dependency_chain: dependency_chain
+         } = file
+       ) do
     metadata =
       metadata
-      |> Map.put(:input_file, Map.get(file, :input_file))
+      |> Map.put(:input_file, input_file)
+      |> Map.put(:dependency_chain, dependency_chain)
 
     Renderer.create(%{file | metadata: metadata})
     |> apply(:render, [])

--- a/lib/still/preprocessor/slime.ex
+++ b/lib/still/preprocessor/slime.ex
@@ -19,10 +19,17 @@ defmodule Still.Preprocessor.Slime do
     %{file | content: do_render(file)}
   end
 
-  defp do_render(%{metadata: metadata} = file) do
+  defp do_render(
+         %{
+           metadata: metadata,
+           input_file: input_file,
+           dependency_chain: dependency_chain
+         } = file
+       ) do
     metadata =
       metadata
-      |> Map.put(:input_file, Map.get(file, :input_file))
+      |> Map.put(:input_file, input_file)
+      |> Map.put(:dependency_chain, dependency_chain)
 
     Renderer.create(%{file | metadata: metadata})
     |> apply(:render, [])

--- a/lib/still/source_file.ex
+++ b/lib/still/source_file.ex
@@ -13,19 +13,21 @@ defmodule Still.SourceFile do
     :input_file,
     :output_file,
     content: nil,
-    metadata: %{},
+    dependency_chain: [],
     extension: nil,
-    run_type: :render,
-    profilable: true
+    metadata: %{},
+    profilable: true,
+    run_type: :render
   ]
 
   @type t :: %__MODULE__{
-          run_type: :render | :compile,
           content: binary() | nil,
+          dependency_chain: list(binary()),
           extension: binary() | nil,
           input_file: binary(),
-          output_file: binary() | nil,
           metadata: map(),
-          profilable: boolean()
+          output_file: binary() | nil,
+          profilable: boolean(),
+          run_type: :render | :compile
         }
 end

--- a/lib/still/watcher.ex
+++ b/lib/still/watcher.ex
@@ -48,7 +48,13 @@ defmodule Still.Watcher do
         process_file(file)
 
       Enum.member?(events, :removed) ->
-        Incremental.Registry.terminate_file_process(file)
+        file
+        |> get_relative_input_path()
+        |> Still.Compiler.ErrorCache.clear()
+
+        file
+        |> get_relative_input_path()
+        |> Incremental.Registry.terminate_file_process()
 
       true ->
         nil

--- a/lib/still/web/error_formatter.ex
+++ b/lib/still/web/error_formatter.ex
@@ -7,7 +7,7 @@ defmodule Still.Web.ErrorFormatter do
   def format(e) do
     """
     <div class='dev-error'>
-      <h1>#{e.source_file.input_file} #{e.message}</h1>
+      <h1>#{error_title(e)}</h1>
       #{render_stacktrace(e) |> String.trim()}
       <h2>Error</h2>
       <pre>
@@ -64,5 +64,11 @@ defmodule Still.Web.ErrorFormatter do
     html
     |> Floki.parse_fragment!()
     |> Floki.raw_html()
+  end
+
+  defp error_title(%{message: message, source_file: %{dependency_chain: dependency_chain}}) do
+    files = Enum.join(dependency_chain, " <- ")
+
+    "#{files} - #{message}"
   end
 end

--- a/test/still/compiler/error_cache_test.exs
+++ b/test/still/compiler/error_cache_test.exs
@@ -1,0 +1,52 @@
+defmodule Still.Compiler.ErrorCacheTest do
+  use Still.Case, async: true
+
+  alias Still.Compiler.{ErrorCache, PreprocessorError}
+  alias Still.SourceFile
+
+  describe "set/1" do
+    test "set an errors for the given" do
+      error = %PreprocessorError{
+        source_file: %SourceFile{
+          input_file: "_header.slime",
+          dependency_chain: ["index.eex", "_header.slime"]
+        }
+      }
+
+      ErrorCache.set({:error, error})
+
+      errors = ErrorCache.get_errors()
+
+      assert not is_nil(errors["index.eex <- _header.slime"])
+    end
+
+    test "doesn't set an error for the given file" do
+      source_file = %SourceFile{
+        input_file: "_header.slime",
+        dependency_chain: ["index.eex", "_header.slime"]
+      }
+
+      ErrorCache.set({:ok, source_file})
+
+      errors = ErrorCache.get_errors()
+
+      assert is_nil(errors["index.eex <- _header.slime"])
+    end
+
+    test "removes an error for the given" do
+      source_file = %SourceFile{
+        input_file: "_header.slime",
+        dependency_chain: ["index.eex", "_header.slime"]
+      }
+
+      error = %PreprocessorError{source_file: source_file}
+
+      ErrorCache.set({:error, error})
+
+      ErrorCache.set({:ok, source_file})
+
+      errors = ErrorCache.get_errors()
+      assert errors["index.html"] == nil
+    end
+  end
+end

--- a/test/still/compiler/file_test.exs
+++ b/test/still/compiler/file_test.exs
@@ -1,7 +1,7 @@
 defmodule Still.Compiler.FileTest do
   use Still.Case, async: false
 
-  alias Still.Compiler
+  alias Still.{Compiler, SourceFile}
   alias Still.Preprocessor.{Frontmatter, Slime, OutputPath, Save, AddContent}
 
   setup do
@@ -32,7 +32,7 @@ defmodule Still.Compiler.FileTest do
     test "renders a slime template" do
       file = "_includes/header.slime"
 
-      content = Compiler.File.render(file, %{})
+      content = Compiler.File.render(%SourceFile{input_file: file, dependency_chain: [file]})
 
       assert %{
                content: "<header><p>This is a header</p></header>",

--- a/test/still/compiler/incremental/node_test.exs
+++ b/test/still/compiler/incremental/node_test.exs
@@ -21,9 +21,8 @@ defmodule Still.Compiler.Incremental.NodeTest do
     })
   end
 
-  describe "process" do
+  describe "compile" do
     test "compiles a file" do
-      CompilationStage.subscribe()
       pid = Registry.get_or_create_file_process("about.slime")
 
       Node.compile(pid)
@@ -37,7 +36,7 @@ defmodule Still.Compiler.Incremental.NodeTest do
 
       other_pid = Registry.get_or_create_file_process("_includes/header.slime")
 
-      Node.render(other_pid, %{}, "about.slime")
+      Node.render(other_pid, %{dependency_chain: ["about.slime"]}, "about.slime")
 
       Node.compile(other_pid)
 
@@ -49,7 +48,7 @@ defmodule Still.Compiler.Incremental.NodeTest do
     test "renders a file" do
       pid = Registry.get_or_create_file_process("_includes/header.slime")
 
-      content = Node.render(pid, %{}, "about.slime")
+      content = Node.render(pid, %{dependency_chain: ["about.slime"]}, "about.slime")
 
       assert %{content: "<header><p>This is a header</p></header>"} = content
     end

--- a/test/still/compiler/view_helpers_test.exs
+++ b/test/still/compiler/view_helpers_test.exs
@@ -4,7 +4,7 @@ defmodule Still.Compiler.ViewHelpersTest do
   alias Still.Compiler.ViewHelpers
 
   defmodule View do
-    use ViewHelpers, input_file: "about.slime"
+    use ViewHelpers, input_file: "about.slime", dependency_chain: []
   end
 
   describe "include/2" do

--- a/test/support/still/case.ex
+++ b/test/support/still/case.ex
@@ -3,12 +3,16 @@ defmodule Still.Case do
 
   using do
     quote do
+      alias Still.Compiler.ErrorCache
+
       import Still.Utils
 
       setup do
         Application.put_env(:still, :pass_through_copy, [])
 
         Still.Utils.clean_output_dir()
+
+        {:ok, _} = ErrorCache.start_link(%{})
 
         :ok
       end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,9 +1,8 @@
-alias Still.Compiler.{Incremental, Collections, ErrorCache, CompilationStage}
+alias Still.Compiler.{Incremental, Collections, CompilationStage}
 
 {:ok, _} = Application.ensure_all_started(:timex)
 {:ok, _} = Application.ensure_all_started(:cachex)
 
-{:ok, _pid} = ErrorCache.start_link(%{})
 {:ok, _pid} = Incremental.Registry.start_link(%{})
 {:ok, _pid} = Collections.start_link(%{})
 {:ok, _pid} = CompilationStage.start_link(%{})

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,11 +1,13 @@
 alias Still.Compiler.{Incremental, Collections, ErrorCache, CompilationStage}
 
 {:ok, _} = Application.ensure_all_started(:timex)
+{:ok, _} = Application.ensure_all_started(:cachex)
 
 {:ok, _pid} = ErrorCache.start_link(%{})
 {:ok, _pid} = Incremental.Registry.start_link(%{})
 {:ok, _pid} = Collections.start_link(%{})
 {:ok, _pid} = CompilationStage.start_link(%{})
+{:ok, _pid} = Cachex.start_link(name: Still.Compiler.ContentCache.cache_name())
 
 ExUnit.start()
 


### PR DESCRIPTION
This change addresses three issues:

1. Sometimes, when an included file fails to render, we don't see the error overlay. This is common for files such as `_layout.slime` that are included mode than once. For instance, if `_layout.slime` throws an error when it's included by file `a.slime` and succeeds when it's included by file `b.slime`, the error will clear and we never see it.
2. Errors are not propagated, so even if we know that `_layout.slime` is failing, we don't know why.
3. When we rename a file, if there was an error for the file, we don't clear it and we can never solve it because there's no file with the registered name.

To solve this we make a couple of changes:

1. `%SourceFile{}` has a `:dependency_chain` which contains the file names of every file included during the compilation process. This means that each compilation will generate a unique `:dependency_chain`, which makes it possible to identify exactly which file is throwing an error and where the compilation started.
2. We no longer return an empty string when the included file fails. We return the error and raise it again on the file including it. This ensures that everything in that compilation chain will fail, so there are no invisible errors.
3. When a file is removed we clear its errors.


Solves https://github.com/still-ex/still/issues/118