### PR TITLE
No longer create compilation nodes for directories

### DIFF
--- a/lib/still/compiler/compilation_stage.ex
+++ b/lib/still/compiler/compilation_stage.ex
@@ -155,12 +155,5 @@ defmodule Still.Compiler.CompilationStage do
   defp compile_file(file) do
     Incremental.Registry.get_or_create_file_process(file)
     |> Incremental.Node.compile()
-    |> case do
-      :ok ->
-        :ok
-
-      _ ->
-        file |> Path.dirname() |> compile_file()
-    end
   end
 end

--- a/lib/still/compiler/incremental/node/compile.ex
+++ b/lib/still/compiler/incremental/node/compile.ex
@@ -25,9 +25,6 @@ defmodule Still.Compiler.Incremental.Node.Compile do
 
   defp do_compile(state) do
     cond do
-      File.dir?(get_input_path(state.file)) ->
-        :error
-
       should_be_ignored?(state.file) ->
         notify_subscribers(state)
         :error

--- a/lib/still/compiler/incremental/registry.ex
+++ b/lib/still/compiler/incremental/registry.ex
@@ -24,6 +24,7 @@ defmodule Still.Compiler.Incremental.Registry do
     if not is_nil(pid) do
       DynamicSupervisor.terminate_child(__MODULE__, pid)
     end
+
     :ok
   end
 

--- a/lib/still/compiler/pass_through_copy.ex
+++ b/lib/still/compiler/pass_through_copy.ex
@@ -82,22 +82,7 @@ defmodule Still.Compiler.PassThroughCopy do
     |> Path.dirname()
     |> File.mkdir_p!()
 
-    if File.dir?(get_input_path(file)) do
-      IO.inspect("processing dir #{file}")
-      process_folder(file, output_file)
-    else
-      process_file(file, output_file)
-    end
-  end
-
-  defp process_file(file, output_file) do
     File.cp(get_input_path(file), get_output_path(output_file))
-  end
-
-  defp process_folder(folder, output_folder) do
-    with {:ok, _} <- File.cp_r(get_input_path(folder), get_output_path(output_folder)) do
-      :ok
-    end
   end
 
   defp get_pass_through_copy_match(file) do

--- a/lib/still/compiler/pass_through_copy.ex
+++ b/lib/still/compiler/pass_through_copy.ex
@@ -83,6 +83,7 @@ defmodule Still.Compiler.PassThroughCopy do
     |> File.mkdir_p!()
 
     if File.dir?(get_input_path(file)) do
+      IO.inspect("processing dir #{file}")
       process_folder(file, output_file)
     else
       process_file(file, output_file)

--- a/lib/still/compiler/traverse.ex
+++ b/lib/still/compiler/traverse.ex
@@ -13,38 +13,40 @@ defmodule Still.Compiler.Traverse do
 
     with true <- File.dir?(get_input_path()),
          _ <- File.rmdir(get_output_path()),
-         :ok <- File.mkdir_p(get_output_path()) do
-      do_run()
-    end
-  end
-
-  defp do_run(folder \\ "") do
-    with {:ok, files} <- File.ls(Path.join(get_input_path(), folder)),
-         files <- Enum.reject(files, &String.starts_with?(&1, "_")),
-         _ <- Enum.map(files, &compile_file(Path.join(folder, &1))) do
-      :ok
+         :ok <- File.mkdir_p(get_output_path()),
+         files <- compilable_files() do
+      files
+      |> Enum.map(&compile_file/1)
     end
   end
 
   defp compile_file(file) do
-    if File.dir?(get_input_path(file)) do
-      process_folder(file)
-    else
-      process_file(file)
-    end
-  end
-
-  defp process_folder(folder) do
-    folder
-    |> Incremental.Registry.get_or_create_file_process()
-    |> Incremental.Node.compile()
-    |> case do
-      {:ok, _} -> :ok
-      _ -> do_run(folder)
-    end
+    process_file(file)
   end
 
   defp process_file(file) do
     file |> CompilationStage.compile()
   end
+
+  def compilable_files(rel_path \\ "") do
+    path = Path.join(get_input_path, rel_path)
+
+    cond do
+      partial?(path) ->
+        []
+
+      File.regular?(path) ->
+        [rel_path]
+
+      File.dir?(path) ->
+        File.ls!(path)
+        |> Enum.map(&compilable_files(Path.join(rel_path, &1)))
+
+      true ->
+        []
+    end
+    |> List.flatten()
+  end
+
+  defp partial?(path), do: String.starts_with?(path, "_")
 end

--- a/lib/still/compiler/traverse.ex
+++ b/lib/still/compiler/traverse.ex
@@ -15,7 +15,7 @@ defmodule Still.Compiler.Traverse do
          _ <- File.rmdir(get_output_path()),
          :ok <- File.mkdir_p(get_output_path()) do
       compilable_files()
-      |> Enum.map(&CompilationStage.compile/1)
+      |> CompilationStage.compile()
     end
   end
 

--- a/lib/still/compiler/traverse.ex
+++ b/lib/still/compiler/traverse.ex
@@ -16,16 +16,8 @@ defmodule Still.Compiler.Traverse do
          :ok <- File.mkdir_p(get_output_path()),
          files <- compilable_files() do
       files
-      |> Enum.map(&compile_file/1)
+      |> Enum.map(&CompilationStage.compile/1)
     end
-  end
-
-  defp compile_file(file) do
-    process_file(file)
-  end
-
-  defp process_file(file) do
-    file |> CompilationStage.compile()
   end
 
   def compilable_files(rel_path \\ "") do

--- a/lib/still/compiler/traverse.ex
+++ b/lib/still/compiler/traverse.ex
@@ -13,9 +13,8 @@ defmodule Still.Compiler.Traverse do
 
     with true <- File.dir?(get_input_path()),
          _ <- File.rmdir(get_output_path()),
-         :ok <- File.mkdir_p(get_output_path()),
-         files <- compilable_files() do
-      files
+         :ok <- File.mkdir_p(get_output_path()) do
+      compilable_files()
       |> Enum.map(&CompilationStage.compile/1)
     end
   end
@@ -24,7 +23,7 @@ defmodule Still.Compiler.Traverse do
     path = Path.join(get_input_path, rel_path)
 
     cond do
-      partial?(path) ->
+      partial?(rel_path) ->
         []
 
       File.regular?(path) ->

--- a/test/still/compiler/pass_through_copy_test.exs
+++ b/test/still/compiler/pass_through_copy_test.exs
@@ -4,16 +4,6 @@ defmodule Still.Compiler.PassThroughCopyTest do
   alias Still.Compiler.PassThroughCopy
 
   describe "try" do
-    test "matches folders" do
-      Application.put_env(:still, :pass_through_copy, css: "styles", img: "img")
-
-      PassThroughCopy.try("css")
-      PassThroughCopy.try("img")
-
-      assert File.exists?(get_output_path("styles"))
-      assert File.exists?(get_output_path("img"))
-    end
-
     test "copies files inside matching folders" do
       Application.put_env(:still, :pass_through_copy, css: "styles")
 


### PR DESCRIPTION
This initially came out as just a refactor, but along the way I noticed a bug that this ended up fixing.

`Traverse` was creating nodes for not just files, but also directories (anything not starting with `_`). This meant that the following structure:
```
images
 |- logo.png
```

would create a node for `images` and another for `images/logo.png`
Both of those nodes would match pass_through rules, and this would essentially result in:
```
cp -r images _site/images
cp -r images/logo.png _site/images/logo.png
```

which is redundant

The new code skips directories alltogether. They're not relevant for the compiler, we only care about the path files are in, and that is still encoded in the file name we use. This simplifies the code a bit. `Traverse` doesn't have to create nodes for directories (which looked weird at that layer), and any other part of the code can skip doing `File.dir?(file)` checks (except for one place which is currently suffering from a separate bug I believe?)