### PR TITLE
[Breaking Change] Template helpers are now pure functions

### DIFF
--- a/guides/introduction/template_languages.md
+++ b/guides/introduction/template_languages.md
@@ -32,7 +32,7 @@ More information can be found in [Template][templates].
 CSS files are regular [templates][templates] where you can embed Elixir:
 
 ```css
-<%= include("_global.scss") %>
+<%= include(@env, "_global.scss") %>
 
 @font-face {
   font-family: IBMPlexMono;

--- a/guides/introduction/templates.md
+++ b/guides/introduction/templates.md
@@ -200,11 +200,11 @@ title: A blog post
 
 This file will be assigned to the collection `post`. Every file that
 specifies the `post` tag will be listed in the `post` collection. You can
-then iterate over this list using the `get_collections` function:
+then iterate over this list using the `get_collections/2` function:
 
 ```slime
 ul
-  = Enum.map get_collections("post"), fn x ->
+  = Enum.map get_collections(@env, "post"), fn x ->
     li
       = link x[:title], to: x[:permalink]
 ```

--- a/installer/priv/templates/priv/site/index.slime
+++ b/installer/priv/templates/priv/site/index.slime
@@ -7,4 +7,4 @@ h1.title Welcome to Still
 .main
   p Hello! <br /> This is your starter to create something beautiful.
 
-  = include("_includes/footer.slime")
+  = include(@env, "_includes/footer.slime")

--- a/lib/still/compiler/template_helpers.ex
+++ b/lib/still/compiler/template_helpers.ex
@@ -24,11 +24,11 @@ defmodule Still.Compiler.TemplateHelpers do
     to: ResponsiveImage,
     as: :render
 
-  defdelegate url_for(_env, relative_path), to: UrlFor, as: :render
+  defdelegate url_for(relative_path), to: UrlFor, as: :render
 
-  defdelegate link_to_css(_env, path, opts \\ []), to: LinkToCSS, as: :render
+  defdelegate link_to_css(path, opts \\ []), to: LinkToCSS, as: :render
 
-  defdelegate link_to_js(_env, path, opts \\ []), to: LinkToJS, as: :render
+  defdelegate link_to_js(path, opts \\ []), to: LinkToJS, as: :render
 
   @doc """
   Renders a file and includes it in the page, using the variables defined in `metadata`.

--- a/lib/still/compiler/template_helpers.ex
+++ b/lib/still/compiler/template_helpers.ex
@@ -4,139 +4,130 @@ defmodule Still.Compiler.TemplateHelpers do
   preprocessor.
   """
 
-  defmacro __using__(metadata) do
-    quote do
-      alias Still.SourceFile
+  alias Still.SourceFile
 
-      alias Still.Compiler.{
-        Incremental,
-        TemplateHelpers.Link,
-        TemplateHelpers.UrlFor,
-        TemplateHelpers.LinkToCSS,
-        TemplateHelpers.LinkToJS,
-        TemplateHelpers.ContentTag,
-        TemplateHelpers.ResponsiveImage,
-        TemplateHelpers.SafeHTML,
-        TemplateHelpers.Truncate,
-        PreprocessorError
-      }
+  alias Still.Compiler.{
+    Incremental,
+    TemplateHelpers.Link,
+    TemplateHelpers.UrlFor,
+    TemplateHelpers.LinkToCSS,
+    TemplateHelpers.LinkToJS,
+    TemplateHelpers.ResponsiveImage,
+    TemplateHelpers.SafeHTML,
+    TemplateHelpers.Truncate,
+    PreprocessorError
+  }
 
-      alias __MODULE__
+  require Logger
 
-      require Logger
+  defdelegate responsive_image(file, opts \\ []),
+    to: ResponsiveImage,
+    as: :render
 
-      @env unquote(metadata)
+  defdelegate url_for(relative_path), to: UrlFor, as: :render
 
-      defdelegate responsive_image(file, opts \\ []),
-        to: ResponsiveImage,
-        as: :render
+  defdelegate link_to_css(path, opts \\ []), to: LinkToCSS, as: :render
 
-      defdelegate url_for(relative_path), to: UrlFor, as: :render
+  defdelegate link_to_js(path, opts \\ []), to: LinkToJS, as: :render
 
-      defdelegate link_to_css(path, opts \\ []), to: LinkToCSS, as: :render
+  @doc """
+  Renders a file and includes it in the page, using the variables defined in `metadata`.
 
-      defdelegate link_to_js(path, opts \\ []), to: LinkToJS, as: :render
+  By default, it creates a subscription to recompile the file in which
+  `include/3` is invoked, when the target `file` changes. This behaviour
+  can be disabled by passing the `:subscribe` option as `false`.
+  """
+  def include(env, file, metadata \\ %{}, opts \\ [])
 
-      @doc """
-      Renders a file and includes it in the page, using the variables defined in `metadata`.
+  def include(env, file, metadata, opts) when is_list(metadata) do
+    include(env, file, metadata |> Enum.into(%{}), opts)
+  end
 
-      By default, it creates a subscription to recompile the file in which
-      `include/3` is invoked, when the target `file` changes. This behaviour
-      can be disabled by passing the `:subscribe` option as `false`.
-      """
-      def include(file, metadata \\ %{}, opts \\ [])
-
-      def include(file, metadata, opts) when is_list(metadata) do
-        include(file, metadata |> Enum.into(%{}), opts)
+  def include(env, file, metadata, opts) do
+    with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
+         subscriber <- include_subscriber(env, opts),
+         metadata <- Map.put(metadata, :dependency_chain, env[:dependency_chain] || []),
+         %SourceFile{content: content} <- Incremental.Node.render(pid, metadata, subscriber) do
+      if subscriber do
+        Incremental.Node.add_subscription(self(), file)
       end
 
-      def include(file, metadata, opts) do
-        with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
-             subscriber <- include_subscriber(opts),
-             metadata <- Map.put(metadata, :dependency_chain, @env[:dependency_chain]),
-             %SourceFile{content: content} <- Incremental.Node.render(pid, metadata, subscriber) do
-          if subscriber do
-            Incremental.Node.add_subscription(self(), file)
-          end
+      content
+    else
+      %PreprocessorError{} = e ->
+        raise e
 
-          content
-        else
-          %PreprocessorError{} = e ->
-            raise e
+      _ ->
+        Logger.error("File process not found for #{file}")
+        ""
+    end
+  end
 
-          _ ->
-            Logger.error("File process not found for #{file}")
-            ""
-        end
-      end
-
-      @doc """
-      Converts a relative path to an absolute one.
+  @doc """
+  Converts a relative path to an absolute one.
 
 
-      ## Examples
+  ## Examples
 
-      File paths are always relative to the root folder, but sometimes it's too
-      cumbersome, and we need to reference a file relative to the current
-      folder.
+  File paths are always relative to the root folder, but sometimes it's too
+  cumbersome, and we need to reference a file relative to the current
+  folder.
 
-      For instance, when called inside the file "blog/post/index.md":
+  For instance, when called inside the file "blog/post/index.md":
 
-          path_expand("./cover.png")
-          # "blog/post/./cover.png"
+      path_expand("./cover.png")
+      # "blog/post/./cover.png"
 
-      """
-      def path_expand(path) do
-        Path.join(Path.dirname(@env[:input_file]), path)
-      end
+  """
+  def path_expand(env, path) do
+    Path.join(Path.dirname(env[:input_file]), path)
+  end
 
-      @doc """
-      Returns the collections for the current file.
-      """
-      def get_collections(collection) do
-        Still.Compiler.Collections.get(collection, @env[:input_file])
-      end
+  @doc """
+  Returns the collections for the current file.
+  """
+  def get_collections(env, collection) do
+    Still.Compiler.Collections.get(collection, env[:input_file])
+  end
 
-      @doc """
-      Renders the link using `Still.Compiler.TemplateHelpers.Link.render/3`.
-      """
-      def link(content, opts) do
-        Link.render(content, @env, opts)
-      end
+  @doc """
+  Renders the link using `Still.Compiler.TemplateHelpers.Link.render/3`.
+  """
+  def link(env, content, opts) do
+    Link.render(env, content, opts)
+  end
 
-      @doc """
-      Safely renders the content by escaping any HTML tags.
-      """
-      def safe_html(content) do
-        SafeHTML.render(content)
-      end
+  @doc """
+  Safely renders the content by escaping any HTML tags.
+  """
+  def safe_html(content) do
+    SafeHTML.render(content)
+  end
 
-      @doc """
-      Truncates the string.
+  @doc """
+  Truncates the string.
 
-      ## Options
+  ## Options
 
-      * `escape` - apply `safe_html/1` after truncating. Defaults to `false`.
+  * `escape` - apply `safe_html/1` after truncating. Defaults to `false`.
 
-      See further supported options in `Still.TemplateHelpers.Truncate`.
-      """
-      def truncate(str, opts \\ []) do
-        truncated = Truncate.render(str, opts)
+  See further supported options in `Still.TemplateHelpers.Truncate`.
+  """
+  def truncate(str, opts \\ []) do
+    truncated = Truncate.render(str, opts)
 
-        if opts[:escape] do
-          safe_html(truncated)
-        else
-          truncated
-        end
-      end
+    if opts[:escape] do
+      safe_html(truncated)
+    else
+      truncated
+    end
+  end
 
-      defp include_subscriber(opts) do
-        if Keyword.get(opts, :subscribe, true) do
-          @env[:input_file]
-        else
-          nil
-        end
-      end
+  defp include_subscriber(env, opts) do
+    if Keyword.get(opts, :subscribe, true) do
+      env[:input_file]
+    else
+      nil
     end
   end
 end

--- a/lib/still/compiler/template_helpers.ex
+++ b/lib/still/compiler/template_helpers.ex
@@ -20,15 +20,15 @@ defmodule Still.Compiler.TemplateHelpers do
 
   require Logger
 
-  defdelegate responsive_image(file, opts \\ []),
+  defdelegate responsive_image(_env, file, opts \\ []),
     to: ResponsiveImage,
     as: :render
 
-  defdelegate url_for(relative_path), to: UrlFor, as: :render
+  defdelegate url_for(_env, relative_path), to: UrlFor, as: :render
 
-  defdelegate link_to_css(path, opts \\ []), to: LinkToCSS, as: :render
+  defdelegate link_to_css(_env, path, opts \\ []), to: LinkToCSS, as: :render
 
-  defdelegate link_to_js(path, opts \\ []), to: LinkToJS, as: :render
+  defdelegate link_to_js(_env, path, opts \\ []), to: LinkToJS, as: :render
 
   @doc """
   Renders a file and includes it in the page, using the variables defined in `metadata`.

--- a/lib/still/compiler/template_helpers/link.ex
+++ b/lib/still/compiler/template_helpers/link.ex
@@ -19,20 +19,20 @@ defmodule Still.Compiler.TemplateHelpers.Link do
   `markup`. Note that this is on demand, outside
   `Still.Compiler.CompilationStage`.
   """
-  def render(opts, metadata, do: markup) do
-    preprocessor = metadata[:preprocessor]
+  def render(env, opts, do: markup) do
+    preprocessor = env[:preprocessor]
 
     %{content: content} =
       preprocessor.render(%SourceFile{
         content: markup,
-        input_file: metadata[:input_file],
-        metadata: metadata |> Enum.into(%{})
+        input_file: env[:input_file],
+        metadata: env |> Enum.into(%{})
       })
 
-    render(content, metadata, opts)
+    render(env, content, opts)
   end
 
-  def render(text, _metadata, opts) do
+  def render(_env, text, opts) do
     {url, opts} = pop_url(opts)
 
     ContentTag.render("a", text, [{:href, url} | opts])

--- a/lib/still/preprocessor/eex/renderer.ex
+++ b/lib/still/preprocessor/eex/renderer.ex
@@ -8,10 +8,8 @@ defmodule Still.Preprocessor.EEx.Renderer do
     preprocessor: Still.Preprocessor.EEx
 
   @impl true
-  def compile(content, _metadata) do
-    info = [file: __ENV__.file, line: __ENV__.line]
-
-    EEx.compile_string(content, info)
+  def compile(content) do
+    EEx.compile_string(content, file: __ENV__.file, line: __ENV__.line)
   end
 
   @impl true

--- a/lib/still/preprocessor/renderer.ex
+++ b/lib/still/preprocessor/renderer.ex
@@ -11,7 +11,7 @@ defmodule Still.Preprocessor.Renderer do
         template_helpers: [Your.Module]
 
   The created module implements a `render/0` which will return the result of
-  the `compile/2` call.
+  the `compile/1` call.
 
   The `ast/0` can be used to tap into the AST of the new module and import or
   require any necessary module.
@@ -25,7 +25,7 @@ defmodule Still.Preprocessor.Renderer do
   """
   @type ast :: {atom(), keyword(), list()}
 
-  @callback compile(String.t(), [{atom(), any()}]) :: ast()
+  @callback compile(String.t()) :: ast()
 
   @callback ast() :: ast()
 
@@ -41,7 +41,7 @@ defmodule Still.Preprocessor.Renderer do
       @preprocessor Keyword.fetch!(unquote(opts), :preprocessor)
       @extensions Keyword.fetch!(unquote(opts), :extensions)
 
-      def create(%SourceFile{input_file: input_file, content: content, metadata: metadata}) do
+      def create(%SourceFile{input_file: input_file, content: content, metadata: metadata} = file) do
         metadata[:input_file]
         |> file_path_to_module_name()
         |> create_template_renderer(content, metadata)
@@ -59,12 +59,13 @@ defmodule Still.Preprocessor.Renderer do
       end
 
       defp create_template_renderer(name, content, metadata) do
-        compiled = compile(content, metadata)
+        compiled = compile(content)
 
-        module_metadata =
-          metadata
-          |> ensure_preprocessor()
-          |> Map.to_list()
+        metadata = Map.put(metadata, :env, metadata)
+
+        assigns = [
+          env: metadata
+        ]
 
         renderer_ast =
           if Kernel.function_exported?(__MODULE__, :ast, 0) do
@@ -80,7 +81,9 @@ defmodule Still.Preprocessor.Renderer do
             unquote(user_template_helpers_asts())
             unquote(renderer_ast)
 
-            use Still.Compiler.TemplateHelpers, unquote(Macro.escape(module_metadata))
+            import Still.Compiler.TemplateHelpers
+
+            Module.put_attribute(__MODULE__, :env, 1)
 
             Enum.map(unquote(Macro.escape(metadata)), fn {k, v} ->
               Module.put_attribute(__MODULE__, k, v)

--- a/lib/still/preprocessor/renderer.ex
+++ b/lib/still/preprocessor/renderer.ex
@@ -83,8 +83,6 @@ defmodule Still.Preprocessor.Renderer do
 
             import Still.Compiler.TemplateHelpers
 
-            Module.put_attribute(__MODULE__, :env, 1)
-
             Enum.map(unquote(Macro.escape(metadata)), fn {k, v} ->
               Module.put_attribute(__MODULE__, k, v)
             end)

--- a/lib/still/preprocessor/slime/renderer.ex
+++ b/lib/still/preprocessor/slime/renderer.ex
@@ -8,11 +8,9 @@ defmodule Still.Preprocessor.Slime.Renderer do
     preprocessor: Still.Preprocessor.Slime
 
   @impl true
-  def compile(content, _metadata) do
-    info = [file: __ENV__.file, line: __ENV__.line]
-
+  def compile(content) do
     Slime.Renderer.precompile(content)
-    |> EEx.compile_string(info)
+    |> EEx.compile_string(file: __ENV__.file, line: __ENV__.line)
   end
 
   @impl true

--- a/priv/site/_includes/community.slime
+++ b/priv/site/_includes/community.slime
@@ -17,7 +17,7 @@
       = link to: "https://github.com/still-ex/still", class: "quote" do
         .mark “
         div
-          = responsive_image("_includes/stars.png", class: "stars")
+          = responsive_image(@env, "_includes/stars.png", class: "stars")
           div Breathtaking, fixed all my issues with static sites.
           div.small -- #{Still.Site.Github.stars} stargazers on GitHub
 

--- a/priv/site/_layout.slime
+++ b/priv/site/_layout.slime
@@ -7,7 +7,7 @@ html
     title Still
     meta charset="UTF-8"
     meta name="viewport" content="width=device-width, initial-scale=1.0"
-    = include("_includes/meta.slime")
+    = include(@env, "_includes/meta.slime")
     = link_to_js "/console.js"
     = link_to_css "/css/theme.css", media: "all"
   body

--- a/priv/site/css/theme.css
+++ b/priv/site/css/theme.css
@@ -1,11 +1,11 @@
-<%= include("css/_reset.css") %>
-<%= include("css/_fonts.css") %>
-<%= include("css/_logo.css") %>
-<%= include("css/_main.css") %>
-<%= include("css/_manifesto.css") %>
-<%= include("css/_getting_started.css") %>
-<%= include("css/_community.css") %>
-<%= include("css/_sponsors.css") %>
+<%= include(@env, "css/_reset.css") %>
+<%= include(@env, "css/_fonts.css") %>
+<%= include(@env, "css/_logo.css") %>
+<%= include(@env, "css/_main.css") %>
+<%= include(@env, "css/_manifesto.css") %>
+<%= include(@env, "css/_getting_started.css") %>
+<%= include(@env, "css/_community.css") %>
+<%= include(@env, "css/_sponsors.css") %>
 
 .visually-hidden {
   clip: rect(0 0 0 0);

--- a/priv/site/index.slime
+++ b/priv/site/index.slime
@@ -2,10 +2,10 @@
 layout: _layout.slime
 ---
 
-= include("_includes/main.slime")
-= include("_includes/manifesto.slime")
-= include("_includes/getting_started.slime")
-= include("_includes/community.slime")
-= include("_includes/sponsors.slime")
+= include(@env, "_includes/main.slime")
+= include(@env, "_includes/manifesto.slime")
+= include(@env, "_includes/getting_started.slime")
+= include(@env, "_includes/community.slime")
+= include(@env, "_includes/sponsors.slime")
 
 = link_to_js "console.js"

--- a/test/fixture/site/about.slime
+++ b/test/fixture/site/about.slime
@@ -2,7 +2,7 @@
 layout: _layout.slime
 title: Still | About
 ---
-= include("_includes/header.slime")
+= include(@env, "_includes/header.slime")
 
 h1 About
 p Hi! I like Elixir.

--- a/test/fixture/site/index.slime
+++ b/test/fixture/site/index.slime
@@ -6,5 +6,5 @@ layout: _layout.slime
   h1 Home page
   p Let's try to list some numbers:
   ul
-    = Enum.map get_collections("post"), fn x ->
+    = Enum.map get_collections(@env, "post"), fn x ->
       li = x["id"]

--- a/test/still/compiler/incremental/node_test.exs
+++ b/test/still/compiler/incremental/node_test.exs
@@ -2,7 +2,6 @@ defmodule Still.Compiler.Incremental.NodeTest do
   use Still.Case, async: false
 
   alias Still.Compiler.Incremental.{Registry, Node}
-  alias Still.Compiler.CompilationStage
 
   alias Still.Preprocessor.{Frontmatter, Slime, AddLayout, AddContent, Save, OutputPath}
 

--- a/test/still/compiler/preprocessor/eex_test.exs
+++ b/test/still/compiler/preprocessor/eex_test.exs
@@ -1,0 +1,32 @@
+defmodule Still.Preprocessor.EExTest do
+  use Still.Case, async: false
+
+  alias Still.Preprocessor.EEx
+  alias Still.SourceFile
+
+  describe "render" do
+    test "compiles a template" do
+      eex = "<p>Still</p>"
+      input_file = "index.eex"
+
+      %{content: html} = EEx.render(%SourceFile{content: eex, input_file: input_file})
+
+      assert html == "<p>Still</p>"
+    end
+
+    test "passes metadata to the template" do
+      eex = "<p><%= @title %></p>"
+      input_file = "index.eex"
+      title = "This is a test"
+
+      %{content: html} =
+        EEx.render(%SourceFile{
+          content: eex,
+          input_file: input_file,
+          metadata: %{title: title}
+        })
+
+      assert html == "<p>This is a test</p>"
+    end
+  end
+end

--- a/test/still/compiler/template_helpers_test.exs
+++ b/test/still/compiler/template_helpers_test.exs
@@ -3,31 +3,29 @@ defmodule Still.Compiler.TemplateHelpersTest do
 
   alias Still.Compiler.TemplateHelpers
 
-  defmodule Template do
-    use TemplateHelpers, input_file: "about.slime", dependency_chain: []
-  end
+  @env [input_file: "about.slime", dependency_chain: []]
 
   describe "include/2" do
     test "renders a file" do
       file = "_includes/header.slime"
 
-      assert "<header><p>This is a header</p></header>" == Template.include(file)
+      assert "<header><p>This is a header</p></header>" == TemplateHelpers.include(@env, file)
     end
 
     test "metadata can be a map or a keyword list" do
       file = "_includes/metadata.slime"
 
       assert "<nav>This include has metadata: Test</nav>" ==
-               Template.include(file, variable: "Test")
+               TemplateHelpers.include(@env, file, variable: "Test")
 
       assert "<nav>This include has metadata: Test</nav>" ==
-               Template.include(file, %{variable: "Test"})
+               TemplateHelpers.include(@env, file, %{variable: "Test"})
     end
 
     test "adds a subscription to the included file" do
       file = "_includes/header.slime"
 
-      Template.include(file)
+      TemplateHelpers.include(@env, file)
 
       assert_receive {_, {:add_subscription, ^file}}, 200
     end


### PR DESCRIPTION
Changing the API of template helpers to always receive `@env` as first argument. Reasons below

This was made after a discussion with @gabrielpoca , which came from #123 

The original issue description felt "wrong" to me in a few ways, and would mean adding more meta magic into a module that already seemed to have a bit too much of it
Even though doing `include("file.css")` instead of `include(@env, "file.css")` within templates feels more comfortable, the magic required to do that seems counter to the usual way Elixir is done. And on a closer look, it actually removes from the template the usual explicitness that comes with Elixir. Those functions were not pure

The original issue would, in my opinion, just increase this problem, because it pushed to allow those helper functions to be called outside templates (by explicitly pasing `@env`) but still keep the original implicit api inside templates. This would make things inconsistent to look at, as well as making the codebase more complicated

Also, from what I understood there were issues with compilation times due to the fact that `use TemplateHelpers` had to be done for every single module (one per template file, I believe?). Changing this to `import TemplateHelpers` should also improve on that
