### PR TITLE
mix still.new - Validate app name

### DIFF
--- a/installer/lib/mix/tasks/still.new.ex
+++ b/installer/lib/mix/tasks/still.new.ex
@@ -29,6 +29,7 @@ defmodule Mix.Tasks.Still.New do
 
       {name, opts} ->
         Project.new([{:name, name} | opts])
+        |> validate_project()
         |> Generator.run()
     end
   end
@@ -49,6 +50,21 @@ defmodule Mix.Tasks.Still.New do
 
       {_opts, _args, [{arg, value} | _]} ->
         Mix.raise("Invalid argument: #{arg}=#{value}")
+    end
+  end
+
+  defp validate_project(%Project{} = project) do
+    check_app_name!(project.name)
+
+    project
+  end
+
+  defp check_app_name!(name) do
+    unless name =~ Regex.recompile!(~r/^[a-z][\w_]*$/) do
+      Mix.raise(
+        "Application name must start with a letter and have only lowercase " <>
+          "letters, numbers and underscore, got: #{inspect(name)}"
+      )
     end
   end
 end


### PR DESCRIPTION
This PR adds validation to the app name. I copied this regex from Phoenix's `mix phx.new` [task](https://github.com/phoenixframework/phoenix/blob/32c906fc96d030113d95e0e8be49299b640c7b1f/installer/lib/mix/tasks/phx.new.ex#L325)
Fixes: #100 

![Screenshot from 2021-03-06 18-22-13](https://user-images.githubusercontent.com/77761194/110225222-ea926400-7ea8-11eb-81f2-5977094bb3c4.png)
