### PR TITLE
mix still.compile exists with an error code

### DIFF
--- a/lib/mix/tasks/still.compile.ex
+++ b/lib/mix/tasks/still.compile.ex
@@ -8,6 +8,7 @@ defmodule Mix.Tasks.Still.Compile do
 
     Still.Compiler.CompilationStage.subscribe()
 
+    Application.put_env(:still, :compiling, true)
     Application.put_env(:still, :url_fingerprinting, true)
     Application.put_env(:still, :dev_layout, false)
 

--- a/lib/mix/tasks/still.compile.ex
+++ b/lib/mix/tasks/still.compile.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Still.Compile do
   use Mix.Task
 
+  @config_key :compilation_task
+
   @doc false
   def run(_) do
     Mix.Task.run("compile")
@@ -8,7 +10,7 @@ defmodule Mix.Tasks.Still.Compile do
 
     Still.Compiler.CompilationStage.subscribe()
 
-    Application.put_env(:still, :compiling, true)
+    Application.put_env(:still, @config_key, true)
     Application.put_env(:still, :url_fingerprinting, true)
     Application.put_env(:still, :dev_layout, false)
 
@@ -20,4 +22,6 @@ defmodule Mix.Tasks.Still.Compile do
       :infinity -> :error
     end
   end
+
+  def config_key, do: @config_key
 end

--- a/lib/still/compiler/incremental/node.ex
+++ b/lib/still/compiler/incremental/node.ex
@@ -124,11 +124,23 @@ defmodule Still.Compiler.Incremental.Node do
         source_file: %Still.SourceFile{input_file: state.file, run_type: :compile}
       }
 
+      Logger.error(error)
       ErrorCache.set({:error, error})
+
+      if Application.get_env(:still, :compiling) do
+        System.stop(1)
+      end
+
       {:reply, :ok, state}
 
     :error, %PreprocessorError{} = e ->
+      Logger.error(e)
       ErrorCache.set({:error, e})
+
+      if Application.get_env(:still, :compiling) do
+        System.stop(1)
+      end
+
       {:reply, :ok, state}
   end
 
@@ -189,7 +201,6 @@ defmodule Still.Compiler.Incremental.Node do
       {:reply, error, state}
 
     :error, %PreprocessorError{} = error ->
-      Logger.error(inspect(error))
       ErrorCache.set({:error, error})
 
       {:reply, error, state}

--- a/lib/still/utils.ex
+++ b/lib/still/utils.ex
@@ -139,6 +139,13 @@ defmodule Still.Utils do
   end
 
   @doc """
+  Returns true when the current execution was started by #{Mix.Tasks.Still.Compile}
+  """
+  def compilation_task? do
+    config(Mix.Tasks.Still.Compile.config_key(), false)
+  end
+
+  @doc """
   Returns the value configured for `:still` by the given key. Errors if it
   doesn't exist.
   """


### PR DESCRIPTION
Running `mix still.compile` doesn't fail when there's an error, leading to a build pipeline passing even though the compilation failed.

Solves https://github.com/still-ex/still/issues/136