### PR TITLE
Experimental Feature: Compilation callbacks

### DIFF
--- a/lib/still/compiler/compilation_stage.ex
+++ b/lib/still/compiler/compilation_stage.ex
@@ -54,9 +54,30 @@ defmodule Still.Compiler.CompilationStage do
     GenServer.call(__MODULE__, :unsubscribe)
   end
 
+  @doc """
+  Register a callback to be run after the compilation cycle but before the
+  subscribers are notified. This function is meant to be used by development
+  libraries only.
+
+  It is particularly useful for making last minute additions after all the
+  preprocessor pipelines have run, such as adding a generated sitemap or
+  minifying assets.
+  """
+  def register(fun) do
+    GenServer.cast(__MODULE__, {:register, fun})
+  end
+
   @impl true
   def init(_) do
-    {:ok, %{to_compile: [], subscribers: [], changed: false, timer: nil}}
+    state = %{
+      to_compile: [],
+      subscribers: [],
+      callbacks: [],
+      changed: false,
+      timer: nil
+    }
+
+    {:ok, state}
   end
 
   @impl true
@@ -88,8 +109,17 @@ defmodule Still.Compiler.CompilationStage do
      }}
   end
 
+  def handle_cast({:register, fun}, state) do
+    callbacks = [fun | state.callbacks] |> Enum.uniq()
+
+    {:noreply, %{state | callbacks: callbacks}}
+  end
+
   @impl true
   def handle_info(:notify_subscribers, %{to_compile: []} = state) do
+    state.callbacks
+    |> Enum.each(fn fun -> fun.() end)
+
     state.subscribers
     |> Enum.each(fn pid ->
       send(pid, :bus_empty)

--- a/lib/still/compiler/compilation_stage.ex
+++ b/lib/still/compiler/compilation_stage.ex
@@ -55,16 +55,16 @@ defmodule Still.Compiler.CompilationStage do
   end
 
   @doc """
-  Register a callback to be run after the compilation cycle but before the
-  subscribers are notified. This function is meant to be used by development
-  libraries only.
+  Register a callback to be run during the compilation cycle, after all the
+  files are compiled but before the subscribers are notified. This function is
+  meant to be used by development libraries only.
 
   It is particularly useful for making last minute additions after all the
   preprocessor pipelines have run, such as adding a generated sitemap or
   minifying assets.
   """
-  def register(fun) do
-    GenServer.cast(__MODULE__, {:register, fun})
+  def on_compile(fun) do
+    GenServer.cast(__MODULE__, {:on_compile, fun})
   end
 
   @impl true
@@ -72,7 +72,7 @@ defmodule Still.Compiler.CompilationStage do
     state = %{
       to_compile: [],
       subscribers: [],
-      callbacks: [],
+      hooks: [],
       changed: false,
       timer: nil
     }
@@ -109,19 +109,21 @@ defmodule Still.Compiler.CompilationStage do
      }}
   end
 
-  def handle_cast({:register, fun}, state) do
-    callbacks = [fun | state.callbacks] |> Enum.uniq()
+  def handle_cast({:on_compile, fun}, state) do
+    hooks = [fun | state.hooks] |> Enum.uniq()
 
-    {:noreply, %{state | callbacks: callbacks}}
+    {:noreply, %{state | hooks: hooks}}
   end
 
   @impl true
   def handle_info(:notify_subscribers, %{to_compile: []} = state) do
-    state.callbacks
-    |> Enum.each(fn fun -> fun.() end)
+    Enum.each(state.hooks, fn
+      {mod, fun, args} -> apply(mod, fun, args)
+      fun when is_function(fun, 0) -> fun.()
+      _ -> :ok
+    end)
 
-    state.subscribers
-    |> Enum.each(fn pid ->
+    Enum.each(state.subscribers, fn pid ->
       send(pid, :bus_empty)
     end)
 

--- a/test/still/compiler/compilation_stage_test.exs
+++ b/test/still/compiler/compilation_stage_test.exs
@@ -1,0 +1,62 @@
+defmodule Still.Compiler.CompilationStageTest do
+  use Still.Case
+
+  alias Still.Compiler.CompilationStage
+
+  describe "handle_cast/2 for :on_compile messages" do
+    test "saves the hook" do
+      mfa = {Kernel, :node, []}
+      captured_fun = &Kernel.node/0
+      anon_fun = fn -> Kernel.node() end
+
+      state_0 = %{hooks: []}
+
+      assert {:noreply, state_1} = CompilationStage.handle_cast({:on_compile, mfa}, state_0)
+
+      assert {:noreply, state_2} =
+               CompilationStage.handle_cast({:on_compile, captured_fun}, state_1)
+
+      assert {:noreply, state_3} = CompilationStage.handle_cast({:on_compile, anon_fun}, state_2)
+
+      assert %{hooks: [_, _, _]} = state_3
+    end
+
+    test "requires unique hooks" do
+      mfa = {Kernel, :node, []}
+      state_0 = %{hooks: []}
+
+      assert {:noreply, state_1} = CompilationStage.handle_cast({:on_compile, mfa}, state_0)
+      assert {:noreply, state_2} = CompilationStage.handle_cast({:on_compile, mfa}, state_1)
+
+      assert %{hooks: [_]} = state_2
+    end
+  end
+
+  describe "handle_info/2 for :notify_subscribers messages when :to_compile is empty" do
+    test "calls the saved hooks" do
+      fun = fn -> send(self(), :called) end
+      state = %{hooks: [fun], to_compile: [], subscribers: []}
+
+      CompilationStage.handle_info(:notify_subscribers, state)
+
+      assert_received :called
+    end
+
+    test "ignores captured functions with the wrong arity" do
+      fun = fn _pid -> send(self(), :called) end
+      state = %{hooks: [fun], to_compile: [], subscribers: []}
+
+      CompilationStage.handle_info(:notify_subscribers, state)
+
+      refute_received :called
+    end
+
+    test "sends the :bus_empty message to subscribers" do
+      state = %{hooks: [], to_compile: [], subscribers: [self()]}
+
+      CompilationStage.handle_info(:notify_subscribers, state)
+
+      assert_received :bus_empty
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an experimental feature (hence the lack of documentation):
compilation callbacks.

Functions that are called (for now without any argument) once the
compilation stage ends but before the subscribers are notified.

This allows plugins to add extra files (e.g: RSS feeds, JS bundles)
before the browser refreshes and other subscribers act.