### PR TITLE
Fix stochastic test and update CI cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Elixir CI
+name: build
 
 on:
   push:
@@ -31,20 +31,25 @@ jobs:
       uses: actions/cache@v2
       with:
         path: deps
-        key: test-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: test-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
+        key: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
 
     - name: Cache build
       uses: actions/cache@v1
       with:
         path: _build
-        key: test-${{ runner.OS }}-${{ matrix.elixir }}-${{ matrix.otp }}-build-
+        key: ${{ runner.OS }}-${{ matrix.elixir }}-${{ matrix.otp }}-build-
         restore-keys: |
-          test-${{ runner.OS }}-${{ matrix.elixir }}-${{ matrix.otp }}-build-
+          ${{ runner.OS }}-${{ matrix.elixir }}-${{ matrix.otp }}-build-
 
     - name: Install dependencies
       run: |
         mix deps.get
+
+    - name: Compile
+      run: |
+        MIX_ENV=dev mix compile
+        MIX_ENV=test mix compile
 
     - name: Run formatter
       run: mix format --check-formatted

--- a/lib/still/compiler/error_cache.ex
+++ b/lib/still/compiler/error_cache.ex
@@ -24,8 +24,19 @@ defmodule Still.Compiler.ErrorCache do
     GenServer.call(__MODULE__, {:set, result})
   end
 
+  @doc """
+  Clears the saved errors for the given input file.
+  """
   def clear(input_file) do
     GenServer.cast(__MODULE__, {:clear, input_file})
+  end
+
+  @doc """
+  Clears the errors for all files. This function is dangerous and should be
+  only used for debugging and testing purposes.
+  """
+  def clear do
+    GenServer.cast(__MODULE__, :clear)
   end
 
   @doc """
@@ -68,6 +79,11 @@ defmodule Still.Compiler.ErrorCache do
   @impl true
   def handle_cast({:clear, input_file}, state) do
     {:noreply, state |> Map.delete(input_file)}
+  end
+
+  @impl true
+  def handle_cast(:clear, _state) do
+    {:noreply, %{}}
   end
 
   def handle_cast(_, state) do

--- a/test/support/still/case.ex
+++ b/test/support/still/case.ex
@@ -1,6 +1,13 @@
 defmodule Still.Case do
   use ExUnit.CaseTemplate
 
+  def ensure_clean_error_cache do
+    case Still.Compiler.ErrorCache.start_link(%{}) do
+      {:ok, _} -> :ok
+      _error -> Still.Compiler.ErrorCache.clear()
+    end
+  end
+
   using do
     quote do
       alias Still.Compiler.ErrorCache
@@ -12,7 +19,7 @@ defmodule Still.Case do
 
         Still.Utils.clean_output_dir()
 
-        {:ok, _} = ErrorCache.start_link(%{})
+        Still.Case.ensure_clean_error_cache()
 
         :ok
       end


### PR DESCRIPTION
Some tests were failing due to the `{:ok, _}` enforced check on
`Still.Case`. If the process is started, then we can just clear it.

This PR also renames the CI cache and compiles everything at once
instead of two separate steps (on `mix test` and `mix credo`), ensuring
the subsequent runs always use cached versions of the build.