### PR TITLE
Better errors using the built-in Exception module

### DIFF
--- a/lib/still/compiler/preprocessor_error.ex
+++ b/lib/still/compiler/preprocessor_error.ex
@@ -1,6 +1,7 @@
 defmodule Still.Compiler.PreprocessorError do
   defexception [
-    :message,
+    :payload,
+    :kind,
     :source_file,
     :preprocessor,
     :remaining_preprocessors,
@@ -9,5 +10,9 @@ defmodule Still.Compiler.PreprocessorError do
 
   require Protocol
 
-  Protocol.derive(Jason.Encoder, __MODULE__, only: [:message, :source_file])
+  Protocol.derive(Jason.Encoder, __MODULE__, only: [:payload, :kind, :source_file])
+
+  def message(error) do
+    Exception.message(error.payload)
+  end
 end

--- a/lib/still/compiler/traverse.ex
+++ b/lib/still/compiler/traverse.ex
@@ -6,10 +6,7 @@ defmodule Still.Compiler.Traverse do
 
   import Still.Utils
 
-  alias Still.Compiler.{
-    CompilationStage,
-    Incremental
-  }
+  alias Still.Compiler.CompilationStage
 
   def run do
     Still.Compiler.Collections.reset()
@@ -23,7 +20,7 @@ defmodule Still.Compiler.Traverse do
   end
 
   def compilable_files(rel_path \\ "") do
-    path = Path.join(get_input_path, rel_path)
+    path = Path.join(get_input_path(), rel_path)
 
     cond do
       partial?(rel_path) ->

--- a/lib/still/preprocessor.ex
+++ b/lib/still/preprocessor.ex
@@ -134,20 +134,13 @@ defmodule Still.Preprocessor do
     preprocessor.run(file)
     |> run(remaining_preprocessors)
   catch
-    :error, %PreprocessorError{} = e ->
-      raise e
+    :error, %PreprocessorError{} = error ->
+      raise error
 
-    :error, %{description: description} when description != "" ->
+    kind, payload ->
       raise PreprocessorError,
-        message: description,
-        preprocessor: preprocessor,
-        remaining_preprocessors: remaining_preprocessors,
-        source_file: file,
-        stacktrace: __STACKTRACE__
-
-    :error, e ->
-      raise PreprocessorError,
-        message: inspect(e),
+        payload: payload,
+        kind: kind,
         preprocessor: preprocessor,
         remaining_preprocessors: remaining_preprocessors,
         source_file: file,

--- a/lib/still/profiler.ex
+++ b/lib/still/profiler.ex
@@ -104,17 +104,18 @@ defmodule Still.Profiler do
 
     ErrorCache.set({:ok, source_file})
   catch
-    :exit, {e, _} ->
+    _, %PreprocessorError{} = e ->
+      ErrorCache.set({:error, e})
+
+    kind, payload ->
       error = %PreprocessorError{
-        message: inspect(e),
+        payload: payload,
+        kind: kind,
         stacktrace: __STACKTRACE__,
         source_file: source_file
       }
 
       ErrorCache.set({:error, error})
-
-    :error, %PreprocessorError{} = e ->
-      ErrorCache.set({:error, e})
   end
 
   defp add_file_render_info(stats, file, delta) do

--- a/priv/still/dev.slime
+++ b/priv/still/dev.slime
@@ -69,6 +69,7 @@ css:
   .dev-error h2 {
     font-size: 20px;
     font-weight: bold;
+    margin-bottom: 8px;
   }
 
   .dev-error pre {

--- a/test/still/compiler/error_cache_test.exs
+++ b/test/still/compiler/error_cache_test.exs
@@ -7,6 +7,8 @@ defmodule Still.Compiler.ErrorCacheTest do
   describe "set/1" do
     test "set an errors for the given" do
       error = %PreprocessorError{
+        payload: :udnef,
+        kind: :error,
         source_file: %SourceFile{
           input_file: "_header.slime",
           dependency_chain: ["index.eex", "_header.slime"]

--- a/test/still/preprocessor_test.exs
+++ b/test/still/preprocessor_test.exs
@@ -110,10 +110,12 @@ defmodule Still.PreprocessorTest do
       p = test("args")
       """
 
-      assert_raise PreprocessorError, "undefined function test/1", fn ->
-        %SourceFile{input_file: file, content: content}
-        |> Preprocessor.run()
-      end
+      assert_raise PreprocessorError,
+                   ~r/.*\d+\: undefined function test\/1/,
+                   fn ->
+                     %SourceFile{input_file: file, content: content}
+                     |> Preprocessor.run()
+                   end
     end
   end
 


### PR DESCRIPTION
I found https://hexdocs.pm/elixir/Exception.html when I was going through Phoenix's source code. With this, we can remove some of the code we have to format errors and format errors in a familiar way to the users. I also moved some things around to ensure we only have to format errors in one place, and we can support any kind of error.