### PR TITLE
Raise when importing files that don't exist

### DIFF
--- a/lib/still/compiler/template_helpers.ex
+++ b/lib/still/compiler/template_helpers.ex
@@ -46,9 +46,7 @@ defmodule Still.Compiler.TemplateHelpers do
   end
 
   def include(env, file, metadata, opts) do
-    if not input_file_exists?(file) do
-      raise "File #{file} does not exist in #{get_input_path()}"
-    end
+    ensure_file_exists!(file)
 
     with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
          subscriber <- include_subscriber(env, opts),
@@ -134,6 +132,12 @@ defmodule Still.Compiler.TemplateHelpers do
       env[:input_file]
     else
       nil
+    end
+  end
+
+  defp ensure_file_exists!(file) do
+    if not input_file_exists?(file) do
+      raise "File #{file} does not exist in #{get_input_path()}"
     end
   end
 end

--- a/lib/still/compiler/template_helpers.ex
+++ b/lib/still/compiler/template_helpers.ex
@@ -18,6 +18,8 @@ defmodule Still.Compiler.TemplateHelpers do
     TemplateHelpers.UrlFor
   }
 
+  import Still.Utils
+
   require Logger
 
   defdelegate responsive_image(file, opts \\ []),
@@ -44,6 +46,10 @@ defmodule Still.Compiler.TemplateHelpers do
   end
 
   def include(env, file, metadata, opts) do
+    if not input_file_exists?(file) do
+      raise "File #{file} does not exist in #{get_input_path()}"
+    end
+
     with pid when not is_nil(pid) <- Incremental.Registry.get_or_create_file_process(file),
          subscriber <- include_subscriber(env, opts),
          metadata <- Map.put(metadata, :dependency_chain, env[:dependency_chain] || []),

--- a/lib/still/utils.ex
+++ b/lib/still/utils.ex
@@ -6,6 +6,15 @@ defmodule Still.Utils do
   alias Still.SourceFile
 
   @doc """
+  Returns true if the given file exists in the input path. Returns false otherwise.
+  """
+  def input_file_exists?(file) do
+    file
+    |> get_input_path()
+    |> File.exists?()
+  end
+
+  @doc """
   Returns the modified time of a given file. Errors if the file does not exist.
   """
   def get_modified_time!(path) do

--- a/test/still/compiler/template_helpers_test.exs
+++ b/test/still/compiler/template_helpers_test.exs
@@ -12,6 +12,16 @@ defmodule Still.Compiler.TemplateHelpersTest do
       assert "<header><p>This is a header</p></header>" == TemplateHelpers.include(@env, file)
     end
 
+    test "raises when the included file does not exist" do
+      file = "_includes/file_does_not_exist.slime"
+
+      assert_raise RuntimeError,
+                   ~r/File _includes\/file_does_not_exist.slime does not exist in.*/,
+                   fn ->
+                     TemplateHelpers.include(@env, file)
+                   end
+    end
+
     test "metadata can be a map or a keyword list" do
       file = "_includes/metadata.slime"
 


### PR DESCRIPTION
In the current implementation, we can import a file that doesn't exist. We'll create a Node for it and then the `AddContent` preprocessor will throw, creating an error in the ErrorCache for a file that doesn't exist. This error is impossible to clear, so we would have to stop the server and start it again. Including a file that doesn't exist should throw an error in the processor including the file.