### PR TITLE
Find preprocessors using a regex

### DIFF
--- a/lib/still/preprocessor.ex
+++ b/lib/still/preprocessor.ex
@@ -149,8 +149,8 @@ defmodule Still.Preprocessor do
   end
 
   defp preprocessors do
-    Enum.to_list(user_defined_preprocessors())
-    |> Enum.concat(Enum.to_list(@default_preprocessors))
+    Enum.concat(user_defined_preprocessors(), @default_preprocessors)
+    |> Enum.to_list()
   end
 
   defp user_defined_preprocessors do

--- a/test/still/preprocessor_test.exs
+++ b/test/still/preprocessor_test.exs
@@ -7,7 +7,6 @@ defmodule Still.PreprocessorTest do
     EEx,
     CSSMinify,
     OutputPath,
-    URLFingerprinting,
     AddContent,
     AddLayout,
     Frontmatter,
@@ -51,9 +50,31 @@ defmodule Still.PreprocessorTest do
   end
 
   describe "for/1" do
-    test "returns the preprocessors for a source_file" do
-      assert [AddContent, EEx, CSSMinify, OutputPath, URLFingerprinting, AddLayout, Save] ==
+    test "returns the preprocessors for a source_file using the file extension" do
+      Application.put_env(:still, :preprocessors, %{
+        ".css" => [
+          AddContent,
+          EEx,
+          CSSMinify,
+          OutputPath,
+          Save
+        ]
+      })
+
+      assert [AddContent, EEx, CSSMinify, OutputPath, Save] ==
                %SourceFile{input_file: "app.css"}
+               |> Preprocessor.for()
+    end
+
+    test "returns the preprocessors for a source_file using a regex" do
+      Application.put_env(:still, :preprocessors, %{
+        ~r/^node_tools\/.*\.js/ => [
+          AddContent
+        ]
+      })
+
+      assert [AddContent] ==
+               %SourceFile{input_file: "node_tools/app.js"}
                |> Preprocessor.for()
     end
   end


### PR DESCRIPTION
This change allows finding the preprocessor chain using a regex instead of just the file extension.

Using the file extensions is fine for simple use cases, but it's not flexible enough. It doesn't make sense to force users to use a custom extension when they need to have two compilation chains for the same file type.