### PR TITLE
Dev Layout waits for websocket to be ready

### DIFF
--- a/priv/still/dev.slime
+++ b/priv/still/dev.slime
@@ -17,8 +17,18 @@ javascript:
   }
 
   window.socket.onopen = () => {
-    window.socket.send("subscribe");
+    waitForConnection(() => window.socket.send("subscribe"), 300);
   };
+
+  function waitForConnection(callback, interval) {
+    if (window.socket.readyState === 1) {
+      callback();
+    } else {
+      setTimeout(function () {
+        waitForConnection(callback, interval);
+      }, interval);
+    }
+  }
 
 css:
   .dev-error-disable-scroll {


### PR DESCRIPTION
Just because the socket is open, it doesn't mean it's ready to send information.
This is a simple change that waits for the ready state to be open.