### PR TITLE
Fix image resize and an option for quality

### DIFF
--- a/lib/still/preprocessor/image.ex
+++ b/lib/still/preprocessor/image.ex
@@ -21,6 +21,11 @@ defmodule Still.Preprocessor.Image do
 
     config :still, :image_adapter, Still.Preprocessor.Image.Imageflow
 
+  The default quality value is 90. To change it, set the `:image_quality` key
+  in the config:
+
+    config :still, :image_quality, 80
+
   For more information see [Mogrify](https://github.com/route/mogrify)'s
   options or [ImageMagick's
   docs](https://imagemagick.org/script/command-line-options.php) information.

--- a/lib/still/preprocessor/image/mogrify.ex
+++ b/lib/still/preprocessor/image/mogrify.ex
@@ -86,7 +86,8 @@ defmodule Still.Preprocessor.Image.Mogrify do
     |> Enum.map(fn {size, output_file} ->
       Task.async(fn ->
         tmp_file
-        |> resize("x#{size}")
+        |> resize(size)
+        |> quality(config(:image_quality, 90))
         |> save(path: get_output_path(output_file))
       end)
     end)


### PR DESCRIPTION
There's a bug in the call to resize images. The current implementation uses "xVALUE", but according to the docs, the syntax to resizes the image by width is "VALUE". The resulting images were huge because the syntax "xVALUE" resizes by height. [Check the docs for more information](https://imagemagick.org/script/command-line-processing.php#geometry).

I also took the opportunity to introduce an option to change the images' quality.