### PR TITLE
Make get_collections mirror documentation

### DIFF
--- a/lib/still/compiler/collections.ex
+++ b/lib/still/compiler/collections.ex
@@ -55,7 +55,7 @@ defmodule Still.Compiler.Collections do
 
   defp find_files(collection, files) do
     files
-    |> Enum.filter(&Enum.member?(Map.get(&1[:metadata], :tag, []), collection))
+    |> Enum.filter(&Enum.member?(Map.get(&1[:metadata], :tags, []), collection))
   end
 
   defp insert_file(file, files) do

--- a/lib/still/compiler/template_helpers.ex
+++ b/lib/still/compiler/template_helpers.ex
@@ -79,10 +79,10 @@ defmodule Still.Compiler.TemplateHelpers do
   end
 
   @doc """
-  Returns the collections for the current file.
+  Returns file metadata based off the provided collection string. 
   """
   def get_collections(_env, collection) do
-    Still.Compiler.Collections.get(collection)
+    Still.Compiler.Collections.get(collection) |> Enum.map(fn x -> Map.get(x, :metadata) end)
   end
 
   @doc """

--- a/lib/still/preprocessor/add_layout.ex
+++ b/lib/still/preprocessor/add_layout.ex
@@ -28,7 +28,7 @@ defmodule Still.Preprocessor.AddLayout do
       when not is_nil(layout_file) do
     layout_metadata =
       metadata
-      |> Map.drop([:tag, :layout, :permalink, :input_file])
+      |> Map.drop([:tags, :layout, :permalink, :input_file])
       |> Map.put(:children, children)
       |> Map.put(:dependency_chain, dependency_chain)
 

--- a/test/still/compiler/collections_test.exs
+++ b/test/still/compiler/collections_test.exs
@@ -8,7 +8,7 @@ defmodule Still.Compiler.CollectionsTest do
 
   describe "get/2" do
     test "retruns the files associated with a given collection" do
-      file = %SourceFile{input_file: "file", metadata: %{tag: ["post"]}}
+      file = %SourceFile{input_file: "file", metadata: %{tags: ["post"]}}
 
       Collections.add(file)
 


### PR DESCRIPTION
created with issue #159 

Updates the `get_collections/2` function and the get `Still.Compile.Collections.find_files/2` functions to match documentation:

https://hexdocs.pm/still/templates.html#collections

The documentation appears to state that the `get_collections/2` function will return the `metadata` for files based on strings under the `tags` key, in the slime file's headers. 

This change updates relevant functions to make this change. 