### PR TITLE
Replace still_snowpack and others with watchers

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,6 @@
 import Config
 
 config :still,
-  dev_layout: true
+  dev_layout: true,
+  ignore_files: [],
+  watchers: []

--- a/guides/introduction/configuration.md
+++ b/guides/introduction/configuration.md
@@ -54,3 +54,29 @@ config :still,
 ```
 
 In the example above, the `css` folder from the input folder but will be renamed to `styles` in the output folder.
+
+## Ignored files
+
+If you want to ignore some files in your input folder, such as files in the `node_modules` folder, or any file containing the word `tailwind`, you can use the setting:
+
+```elixir
+config :still,
+  ignore_files: ["node_modules", ~r/tailwind/]
+```
+
+This setting is similar to [Passthrough copy](#passthrough-copy).
+
+## Watchers
+
+Watchers are external processes managed by Still. You can use watchers to run something like tailwind or webpack. For instance, if the `assets` folder contains your `tailwind.config.js`, the following settings will remove `assets` from the compilation pipeline, and start tailwind on that folder:
+
+
+```elixir
+config :still,
+  ignore_files: ["assets"],
+  watchers: [
+    npx: ["tailwindcss", "-o", "../global.css", "--watch", cd: "priv/site/assets"]
+  ]
+```
+
+ Tailwind will generate a `global.css` in the root of your website, which will be picked up by Still and turned into a file on your website.

--- a/guides/introduction/getting_started.md
+++ b/guides/introduction/getting_started.md
@@ -6,7 +6,7 @@ Still is a simple static site generator for pragmatic developers. It's a modern 
 
 ## Quick start
 
-Still is in early active development. It requires at least Elixir 1.11.3 and Erlang 23.0.3. It may work with previous versions, but these are the versions we are using at the moment.
+Still is in early active development. It requires at least Elixir 1.11.3 and Erlang 23.0.3. It may work with previous versions, but these are the versions we are building on.
 
 To bootstrap a new site, run the following commands:
 
@@ -52,6 +52,20 @@ Run `mix still.dev` to start the development server. Then your website will be a
 Still is watching your file system for changes and it refreshes the browser when necessary. If there are any errors building the website, they will show up on the browser, along with the stack trace and the context where the error happen.
 
 If you run `iex -S mix still.dev` you'll get an interactive shell where you can test things quickly, such as API calls.
+
+## Building a website
+
+Still takes the files in your input folder, which is `priv/site/` by default, and turns them into a website. The input folder is where you'll spend most of time, writing Slime templates and CSS. Add a new file `about.slime` to your input folder with the contents:
+
+```
+---
+layout: _layout.slime
+---
+
+h1 About
+```
+
+And a new page will be available in [http://localhost:3000/about](http://localhost:3000/about).
 
 ## Production
 

--- a/guides/introduction/plugins.md
+++ b/guides/introduction/plugins.md
@@ -1,9 +1,0 @@
-# Plugins
-
-- [still_snowpack](https://github.com/still-ex/still_snowpack) adds
-  [Snowpack][snowpack] support to stiil, making it simple to use
-  packages from the Javascript ecosystem in your site.
-- [still_node](https://github.com/still-ex/still_node) allows you to
-  run and communicate with Node processes.
-
-[snowpack]: https://www.snowpack.dev/

--- a/guides/introduction/plugins.md
+++ b/guides/introduction/plugins.md
@@ -1,0 +1,6 @@
+# Plugins
+
+- [still_node](https://github.com/still-ex/still_node) allows you to
+  run and communicate with Node processes.
+
+[snowpack]: https://www.snowpack.dev/

--- a/lib/still/application.ex
+++ b/lib/still/application.ex
@@ -14,9 +14,9 @@ defmodule Still.Application do
 
     children =
       base_children() ++
-      server_children() ++
+        server_children() ++
         profiler_children() ++
-          process_watchers_children()
+        process_watchers_children()
 
     opts = [strategy: :one_for_one, name: Still.Supervisor]
 

--- a/lib/still/application.ex
+++ b/lib/still/application.ex
@@ -12,7 +12,12 @@ defmodule Still.Application do
     # file is rendered.
     Code.compiler_options(ignore_module_conflict: true)
 
-    children = base_children() ++ server_children() ++ profiler_children()
+    children =
+      base_children() ++
+      server_children() ++
+        profiler_children() ++
+          process_watchers_children()
+
     opts = [strategy: :one_for_one, name: Still.Supervisor]
 
     if server?() do
@@ -45,6 +50,14 @@ defmodule Still.Application do
   defp profiler_children do
     if profiler?() do
       [Still.Profiler]
+    else
+      []
+    end
+  end
+
+  defp process_watchers_children do
+    if server?() do
+      Enum.map(config(:watchers, []), &{Still.ProcessWatcher, &1})
     else
       []
     end

--- a/lib/still/compiler/traverse.ex
+++ b/lib/still/compiler/traverse.ex
@@ -21,6 +21,9 @@ defmodule Still.Compiler.Traverse do
     path = Path.join(get_input_path(), rel_path)
 
     cond do
+      ignored_file?(rel_path) ->
+        []
+
       partial?(rel_path) ->
         []
 

--- a/lib/still/process_watcher.ex
+++ b/lib/still/process_watcher.ex
@@ -17,17 +17,15 @@ defmodule Still.ProcessWatcher do
   end
 
   def watch(_cmd, {mod, fun, args}) do
-    try do
-      apply(mod, fun, args)
-    catch
-      kind, reason ->
-        # The function returned a non-zero exit code.
-        # Sleep for a couple seconds before exiting to
-        # ensure this doesn't hit the supervisor's
-        # max_restarts/max_seconds limit.
-        Process.sleep(2000)
-        :erlang.raise(kind, reason, __STACKTRACE__)
-    end
+    apply(mod, fun, args)
+  catch
+    kind, reason ->
+      # The function returned a non-zero exit code.
+      # Sleep for a couple seconds before exiting to
+      # ensure this doesn't hit the supervisor's
+      # max_restarts/max_seconds limit.
+      Process.sleep(2000)
+      :erlang.raise(kind, reason, __STACKTRACE__)
   end
 
   def watch(cmd, args) when is_list(args) do

--- a/lib/still/process_watcher.ex
+++ b/lib/still/process_watcher.ex
@@ -1,4 +1,5 @@
 # Copied from [Phoenix](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/endpoint/watcher.ex).
+# credo:disable-for-this-file
 
 defmodule Still.ProcessWatcher do
   @moduledoc false

--- a/lib/still/process_watcher.ex
+++ b/lib/still/process_watcher.ex
@@ -1,0 +1,62 @@
+# https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/endpoint/watcher.ex
+
+defmodule Still.ProcessWatcher do
+  @moduledoc false
+  require Logger
+
+  def child_spec(args) do
+    %{
+      id: make_ref(),
+      start: {__MODULE__, :start_link, [args]},
+      restart: :transient
+    }
+  end
+
+  def start_link({cmd, args}) do
+    Task.start_link(__MODULE__, :watch, [to_string(cmd), args])
+  end
+
+  def watch(_cmd, {mod, fun, args}) do
+    try do
+      apply(mod, fun, args)
+    catch
+      kind, reason ->
+        # The function returned a non-zero exit code.
+        # Sleep for a couple seconds before exiting to
+        # ensure this doesn't hit the supervisor's
+        # max_restarts/max_seconds limit.
+        Process.sleep(2000)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    end
+  end
+
+  def watch(cmd, args) when is_list(args) do
+    {args, opts} = Enum.split_while(args, &is_binary(&1))
+    opts = Keyword.merge([into: IO.stream(:stdio, :line), stderr_to_stdout: true], opts)
+
+    try do
+      System.cmd(cmd, args, opts)
+    catch
+      :error, :enoent ->
+        relative = Path.relative_to_cwd(cmd)
+
+        Logger.error(
+          "Could not start watcher #{inspect(relative)} from #{inspect(cd(opts))}, executable does not exist"
+        )
+
+        exit(:shutdown)
+    else
+      {_, 0} ->
+        :ok
+
+      {_, _} ->
+        # System.cmd returned a non-zero exit code
+        # sleep for a couple seconds before exiting to ensure this doesn't
+        # hit the supervisor's max_restarts / max_seconds limit
+        Process.sleep(2000)
+        exit(:watcher_command_error)
+    end
+  end
+
+  defp cd(opts), do: opts[:cd] || File.cwd!()
+end

--- a/lib/still/process_watcher.ex
+++ b/lib/still/process_watcher.ex
@@ -1,4 +1,4 @@
-# https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/endpoint/watcher.ex
+# Copied from [Phoenix](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/endpoint/watcher.ex).
 
 defmodule Still.ProcessWatcher do
   @moduledoc false

--- a/lib/still/utils.ex
+++ b/lib/still/utils.ex
@@ -10,6 +10,27 @@ defmodule Still.Utils do
     :module == elem(Code.ensure_compiled(module), 0)
   end
 
+  def ignored_file?(file) do
+    config(:ignore_files, [])
+    |> Enum.any?(&ignored_file_match(file, &1))
+  end
+
+  defp ignored_file_match(file, {match, _output}) when is_binary(match),
+    do: ignored_file_match(file, match)
+
+  defp ignored_file_match(file, {match, _output}) when is_atom(match),
+    do: ignored_file_match(file, match |> Atom.to_string())
+
+  defp ignored_file_match(file, match) when is_binary(match),
+    do: String.starts_with?(file, match)
+
+  defp ignored_file_match(file, match) do
+    cond do
+      Regex.regex?(match) -> String.match?(file, match)
+      true -> false
+    end
+  end
+
   @doc """
   Compiles a file.
   """

--- a/lib/still/utils.ex
+++ b/lib/still/utils.ex
@@ -10,16 +10,14 @@ defmodule Still.Utils do
     :module == elem(Code.ensure_compiled(module), 0)
   end
 
+  @doc """
+  Checks whether a file should be ignored by Still or not.
+  """
+  @spec ignored_file?(binary()) :: boolean()
   def ignored_file?(file) do
     config(:ignore_files, [])
     |> Enum.any?(&ignored_file_match(file, &1))
   end
-
-  defp ignored_file_match(file, {match, _output}) when is_binary(match),
-    do: ignored_file_match(file, match)
-
-  defp ignored_file_match(file, {match, _output}) when is_atom(match),
-    do: ignored_file_match(file, match |> Atom.to_string())
 
   defp ignored_file_match(file, match) when is_binary(match),
     do: String.starts_with?(file, match)

--- a/lib/still/watcher.ex
+++ b/lib/still/watcher.ex
@@ -48,6 +48,9 @@ defmodule Still.Watcher do
   """
   def handle_info({:file_event, _watcher_pid, {file, events}}, state) do
     cond do
+      ignored_file?(get_relative_input_path(file)) ->
+        nil
+
       Enum.member?(events, :removed) or Enum.member?(events, :renamed) ->
         remove_file(file)
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,6 @@ defmodule Still.MixProject do
         "guides/introduction/getting_started.md",
         "guides/introduction/templates.md",
         "guides/introduction/configuration.md",
-        "guides/introduction/plugins.md",
         "guides/advanced/preprocessors.md",
         "guides/advanced/hooks.md"
       ],

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Still.MixProject do
         "guides/introduction/getting_started.md",
         "guides/introduction/templates.md",
         "guides/introduction/configuration.md",
+        "guides/introduction/plugins.md",
         "guides/advanced/preprocessors.md",
         "guides/advanced/hooks.md"
       ],


### PR DESCRIPTION
After [`still_snowpack`](https://github.com/still-ex/still_snowpack), I wanted to write a plugin to integrate with Tailwind. I spent a lot of time thinking about this, about the ergonomics and how other projects did it, and I believe we are going in the wrong direction. The setup for `still_snowpack` is confusing and most of it could be accomplished through the CLI. And the same applies to Tailwind, where running the binary would be more than enough.

There are scenarios where it makes sense to build on top of [`still_node`](https://github.com/still-ex/still_node), but that shouldn't be the only solution. This is where `watchers` come in (it was literally copy-pasted from Phoenix). You can see on the example I wrote for tailwind that with just one config you have tailwind up and running and integrated with Still.

On top of that, the `ignored_file` config allows us to have the Node projects inside the input folder, next to the rest of the code.