### PR TITLE
Pass through copy ignores files that have not been modified

### DIFF
--- a/lib/still/compiler/pass_through_copy.ex
+++ b/lib/still/compiler/pass_through_copy.ex
@@ -69,7 +69,6 @@ defmodule Still.Compiler.PassThroughCopy do
   defp run(file, output_file) do
     case do_run(file, output_file) do
       :ok ->
-        Logger.info("Pass through copy #{file}")
         :ok
 
       _ ->
@@ -78,12 +77,17 @@ defmodule Still.Compiler.PassThroughCopy do
     end
   end
 
-  defp do_run(file, output_file) do
-    get_output_path(output_file)
-    |> Path.dirname()
-    |> File.mkdir_p!()
+  defp do_run(input_file, output_file) do
+    if input_file_changed?(input_file, output_file) do
+      get_output_path(output_file)
+      |> Path.dirname()
+      |> File.mkdir_p!()
 
-    File.cp(get_input_path(file), get_output_path(output_file))
+      Logger.info("Pass through copy #{input_file}")
+      File.cp(get_input_path(input_file), get_output_path(output_file))
+    else
+      :ok
+    end
   end
 
   defp get_pass_through_copy_match(file) do

--- a/lib/still/preprocessor/image/mogrify.ex
+++ b/lib/still/preprocessor/image/mogrify.ex
@@ -25,7 +25,7 @@ defmodule Still.Preprocessor.Image.Mogrify do
       |> Map.get(:sizes, [])
       |> get_output_files_with_sizes(output_file, opts)
 
-    if input_file_changed?(input_file, output_files) do
+    if file_changed?(input_file, output_files) do
       process_input_file(input_file, opts, output_files)
     end
 
@@ -46,22 +46,8 @@ defmodule Still.Preprocessor.Image.Mogrify do
     end
   end
 
-  defp input_file_changed?(input_file, [{_, output_file} | _]) do
-    input_mtime =
-      input_file
-      |> get_input_path()
-      |> get_modified_time!()
-
-    output_file
-    |> get_output_path()
-    |> get_modified_time()
-    |> case do
-      {:ok, output_mtime} ->
-        Timex.compare(input_mtime, output_mtime) != -1
-
-      _ ->
-        true
-    end
+  defp file_changed?(input_file, [{_, output_file} | _]) do
+    input_file_changed?(input_file, output_file)
   end
 
   defp get_output_files_with_sizes(sizes, output_file_path, opts) do

--- a/lib/still/utils.ex
+++ b/lib/still/utils.ex
@@ -57,6 +57,25 @@ defmodule Still.Utils do
   end
 
   @doc """
+  Returns true if the modified time of the imput file is different than the output file.
+  """
+  def input_file_changed?(input_file, output_file) do
+    with {:ok, input_mtime} <-
+           input_file
+           |> get_input_path()
+           |> get_modified_time(),
+         {:ok, output_mtime} <-
+           output_file
+           |> get_output_path()
+           |> get_modified_time() do
+      Timex.compare(input_mtime, output_mtime) != -1
+    else
+      _ ->
+        true
+    end
+  end
+
+  @doc """
   Returns the modified time of a given file. Errors if the file does not exist.
   """
   def get_modified_time!(path) do


### PR DESCRIPTION
The modified time is used to check if the input file is not modified. If not, we don't copy the file to the output folder again.