### PR TITLE
Fix tag inconsistency in test

### DIFF
--- a/guides/introduction/template_languages.md
+++ b/guides/introduction/template_languages.md
@@ -16,7 +16,7 @@ Files with the extension `.md` will be treated as Markdown and generate `.html` 
 
 ```md
 ---
-tags:
+tag:
   - post
 ---
 
@@ -32,11 +32,9 @@ More information can be found in [Template][templates].
 CSS files are regular [templates][templates] where you can embed Elixir:
 
 ```css
-<%= include(@env, "_global.scss") %>
-
-@font-face {
+<%= include(@env, "_global.scss") % > @font-face {
   font-family: IBMPlexMono;
-  src: url(<%= url_for("/fonts/IBMPlexMono-Regular.ttf") %>);
+  src: url(<%=url_for("/fonts/IBMPlexMono-Regular.ttf")%>);
 }
 ```
 
@@ -45,7 +43,7 @@ CSS files are regular [templates][templates] where you can embed Elixir:
 JavaScript files are regular [templates][templates] where you can embed Elixir:
 
 ```js
-console.log('<%= link_to("img/bg.jpg") %>')
+console.log('<%= link_to("img/bg.jpg") %>');
 ```
 
 ## Custom

--- a/guides/introduction/template_languages.md
+++ b/guides/introduction/template_languages.md
@@ -32,9 +32,11 @@ More information can be found in [Template][templates].
 CSS files are regular [templates][templates] where you can embed Elixir:
 
 ```css
-<%= include(@env, "_global.scss") % > @font-face {
+<%= include(@env, "_global.scss") %>
+
+@font-face {
   font-family: IBMPlexMono;
-  src: url(<%=url_for("/fonts/IBMPlexMono-Regular.ttf")%>);
+  src: url(<%= url_for("/fonts/IBMPlexMono-Regular.ttf") %>);
 }
 ```
 
@@ -43,7 +45,7 @@ CSS files are regular [templates][templates] where you can embed Elixir:
 JavaScript files are regular [templates][templates] where you can embed Elixir:
 
 ```js
-console.log('<%= link_to("img/bg.jpg") %>');
+console.log('<%= link_to("img/bg.jpg") %>')
 ```
 
 ## Custom

--- a/test/still/preprocessor_test.exs
+++ b/test/still/preprocessor_test.exs
@@ -113,14 +113,14 @@ defmodule Still.PreprocessorTest do
       content = """
       ---
       hello: world
-      tags:
+      tag:
         - post
         - article
       ---
       p Hello
       """
 
-      assert %{content: "<p>Hello</p>", metadata: %{hello: "world", tags: ["post", "article"]}} =
+      assert %{content: "<p>Hello</p>", metadata: %{hello: "world", tag: ["post", "article"]}} =
                Preprocessor.run(%SourceFile{input_file: file, content: content})
     end
 


### PR DESCRIPTION
This is fairly inconsequential, but I found this misleading given the changes in #160

Could you also publish new hexdocs as https://hexdocs.pm/still/templates.html#content still mentions `tags` - wasted a lot of time troubleshooting that 😭 