### PR TITLE
Fix collection links example

### DIFF
--- a/guides/introduction/templates.md
+++ b/guides/introduction/templates.md
@@ -204,9 +204,8 @@ then iterate over this list using the `get_collections/2` function:
 
 ```slime
 ul
-  = Enum.map(get_collections(@env, "post"), fn x -> Map.get(x, :metadata) end) |> Enum.map fn x ->
-    li
-      = link x[:title], to: x[:permalink]
+  = Enum.map get_collections(@env, "post"), fn x ->
+    = link @env, x[:metadata][:title], to: x[:output_file]
 ```
 
 Collections are automatically updated when the files change. Files that

--- a/test/fixture/site/index.slime
+++ b/test/fixture/site/index.slime
@@ -7,4 +7,4 @@ layout: _layout.slime
   p Let's try to list some numbers:
   ul
     = Enum.map get_collections(@env, "post"), fn x ->
-      li = x["id"]
+      = link @env, x[:metadata][:title], to: x[:output_file]

--- a/test/fixture/site/index.slime
+++ b/test/fixture/site/index.slime
@@ -4,7 +4,7 @@ layout: _layout.slime
 
 #id.class
   h1 Home page
-  p Let's try to list some numbers:
+  p Let's try to list some posts:
   ul
     = Enum.map get_collections(@env, "post"), fn x ->
       = link @env, x[:metadata][:title], to: x[:output_file]

--- a/test/fixture/site/posts/post_1.slime
+++ b/test/fixture/site/posts/post_1.slime
@@ -1,5 +1,6 @@
 ---
 layout: _layout.slime
+title: Post 1
 tag:
   - post
 ---

--- a/test/fixture/site/posts/post_2.slime
+++ b/test/fixture/site/posts/post_2.slime
@@ -1,5 +1,6 @@
 ---
 layout: _layout.slime
+title: Post 2
 tag:
   - post
 ---


### PR DESCRIPTION
The example in the documentation didn't work for me for a couple reasons

- There's no `permalink` on the `metadata` key in the collection
- `link` is a 3 arity function that takes `env` as the first arg

I modified the included test to use what the documentation shows