### PR TITLE
Document the Mix tasks

### DIFF
--- a/lib/mix/tasks/still.compile.ex
+++ b/lib/mix/tasks/still.compile.ex
@@ -1,5 +1,10 @@
 defmodule Mix.Tasks.Still.Compile do
+  @moduledoc """
+  Compiles your site into an output folder, which is `_site` by default.
+  """
   use Mix.Task
+
+  @shortdoc "Compiles your site"
 
   @config_key :compilation_task
 
@@ -15,5 +20,6 @@ defmodule Mix.Tasks.Still.Compile do
     Still.Compiler.Compile.run()
   end
 
+  @doc false
   def config_key, do: @config_key
 end

--- a/lib/mix/tasks/still.dev.ex
+++ b/lib/mix/tasks/still.dev.ex
@@ -1,5 +1,18 @@
 defmodule Mix.Tasks.Still.Dev do
+  @moduledoc """
+  Starts the development server.
+  Your website will be available in <http://localhost:3000>.
+
+  Still is watching your file system for changes and it refreshes the browser when necessary.
+  If there are any errors building the website, they will show up on the browser, along with the stack trace and the context where the error happened.
+
+  If you run `iex -S mix still.dev` you'll get an interactive shell where you can test things quickly, such as API calls.
+
+  Accepts the same command-line arguments as `mix run`.
+  """
   use Mix.Task
+
+  @shortdoc "Starts the development server"
 
   @doc false
   def run(_) do


### PR DESCRIPTION
This will make the mix tasks show up with `mix help`,
and will provide a little more information with `mix help still.dev`.