### PR TITLE
Pass all metadata to the included file

### DIFF
--- a/lib/still/compiler/incremental/output_to_input_file_registry.ex
+++ b/lib/still/compiler/incremental/output_to_input_file_registry.ex
@@ -32,6 +32,7 @@ defmodule Still.Compiler.Incremental.OutputToInputFileRegistry do
     Registry.lookup(__MODULE__, output_path)
     |> Enum.flat_map(fn {_pid, input_file} ->
       compile_file(input_file, run_type: :compile_dev, requested_output_file: output_file)
+      |> to_list()
     end)
     |> Enum.filter(fn v -> v != :ok end)
     |> Enum.filter(fn %{output_file: other_output_file} -> output_file == other_output_file end)

--- a/lib/still/compiler/template_helpers.ex
+++ b/lib/still/compiler/template_helpers.ex
@@ -43,7 +43,7 @@ defmodule Still.Compiler.TemplateHelpers do
   def include(env, file, metadata) do
     ensure_file_exists!(file)
 
-    metadata = Map.put(metadata, :dependency_chain, env[:dependency_chain])
+    metadata = Map.merge(env, metadata)
 
     with source_files <- Incremental.Node.Render.run(file, metadata),
          %SourceFile{content: content} <- SourceFile.for_extension(source_files, env.extension) do

--- a/lib/still/web/socket_handler.ex
+++ b/lib/still/web/socket_handler.ex
@@ -34,8 +34,6 @@ defmodule Still.Web.SocketHandler do
         [error | _] ->
           send(self(), Jason.encode!(%{type: "error", data: ErrorFormatter.format(error)}))
       end
-
-      ErrorCache.clear()
     end
 
     {:ok, state}

--- a/test/still/compiler/error_cache_test.exs
+++ b/test/still/compiler/error_cache_test.exs
@@ -4,14 +4,14 @@ defmodule Still.Compiler.ErrorCacheTest do
   alias Still.Compiler.{ErrorCache, PreprocessorError}
   alias Still.SourceFile
 
-  describe "set/1" do
-    test "set an errors for the given" do
+  describe "set/1 with an error" do
+    test "sets the given error" do
       error = %PreprocessorError{
         payload: :udnef,
         kind: :error,
         source_file: %SourceFile{
           input_file: "_header.slime",
-          dependency_chain: ["index.eex", "_header.slime"]
+          dependency_chain: ["_header.slime", "index.slime"]
         }
       }
 
@@ -19,36 +19,63 @@ defmodule Still.Compiler.ErrorCacheTest do
 
       errors = ErrorCache.get_errors()
 
-      assert not is_nil(errors["index.eex <- _header.slime"])
+      assert not is_nil(errors["_header.slime <- index.slime"])
     end
+  end
 
-    test "doesn't set an error for the given file" do
+  describe "set/1 without an error" do
+    test "doesn't set an error" do
       source_file = %SourceFile{
         input_file: "_header.slime",
-        dependency_chain: ["index.eex", "_header.slime"]
+        dependency_chain: ["_header.slime", "index.slime"]
       }
 
       ErrorCache.set({:ok, source_file})
 
       errors = ErrorCache.get_errors()
 
-      assert is_nil(errors["index.eex <- _header.slime"])
+      assert is_nil(errors["index.slime <- _header.slime"])
     end
 
-    test "removes an error for the given" do
+    test "removes errors for the given file" do
       source_file = %SourceFile{
         input_file: "_header.slime",
-        dependency_chain: ["index.eex", "_header.slime"]
+        dependency_chain: ["_header.slime", "index.slime"]
       }
 
       error = %PreprocessorError{source_file: source_file}
+      ErrorCache.set({:error, error})
 
+      source_file = %SourceFile{
+        input_file: "_header.slime",
+        dependency_chain: ["_header.slime", "about.slime"]
+      }
+
+      error = %PreprocessorError{source_file: source_file}
       ErrorCache.set({:error, error})
 
       ErrorCache.set({:ok, source_file})
 
       errors = ErrorCache.get_errors()
-      assert errors["index.html"] == nil
+
+      assert is_nil(errors["_header.slime <- index.slime"])
+      assert is_nil(errors["_header.slime <- about.slime"])
+    end
+
+    test "recompiles initial files for existing errors of the same file" do
+      source_file = %SourceFile{
+        input_file: "_header.slime",
+        dependency_chain: ["_header.slime", "now.slime"]
+      }
+
+      error = %PreprocessorError{source_file: source_file}
+      ErrorCache.set({:error, error})
+
+      Process.register(self(), :"now.slime")
+
+      ErrorCache.set({:ok, source_file})
+
+      assert_receive {_, _, {:compile_metadata, _}}
     end
   end
 end


### PR DESCRIPTION
When including another file, pass all the metadata along. Metadata can still be overridden.