### PR TITLE
set EEx preprocessor output extension to .html

### DIFF
--- a/lib/still/preprocessor/eex.ex
+++ b/lib/still/preprocessor/eex.ex
@@ -12,8 +12,8 @@ defmodule Still.Preprocessor.EEx do
   use Preprocessor
 
   @impl true
-  def render(%{extension: extension} = source_file) do
-    %{source_file | content: do_render(source_file), extension: extension || ".html"}
+  def render(source_file) do
+    %{source_file | content: do_render(source_file), extension: ".html"}
   end
 
   defp do_render(source_file) do


### PR DESCRIPTION
Looks like this was working previously but was broken by the latest change, for reasons I can't discern from the commit history. This once again sets the file extension of the output file to ".html" rather than passing it through as ".eex" from the source file.